### PR TITLE
Allow parsing `null` in JSON

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -414,6 +414,14 @@ func (sl *StringLiteral) expressionNode()      {}
 func (sl *StringLiteral) TokenLiteral() string { return sl.Token.Literal }
 func (sl *StringLiteral) String() string       { return sl.Token.Literal }
 
+type NullLiteral struct {
+	Token token.Token
+}
+
+func (nl *NullLiteral) expressionNode()      {}
+func (nl *NullLiteral) TokenLiteral() string { return "null" }
+func (nl *NullLiteral) String() string       { return "null" }
+
 type ArrayLiteral struct {
 	Token    token.Token // the '[' token
 	Elements []Expression

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -60,6 +60,9 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 	case *ast.NumberLiteral:
 		return &object.Number{Value: node.Value}
 
+	case *ast.NullLiteral:
+		return NULL
+
 	case *ast.StringLiteral:
 		return &object.String{Value: node.Value}
 

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -590,6 +590,8 @@ func TestBuiltinFunctions(t *testing.T) {
 		{`type({})`, "HASH"},
 		{`type([])`, "ARRAY"},
 		{`type("{}".json())`, "HASH"},
+		{`"{\"a\": null}".json().a`, nil},
+		{`type(null)`, "NULL"},
 		{`"{\"k\": \"v\"}".json()["k"]`, "v"},
 		{`"hello".json()`, "argument to `json` must be a valid JSON object, got 'hello'"},
 		{`"\"hello".json()`, "argument to `json` must be a valid JSON object, got '\"hello'"},

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -68,6 +68,8 @@ one | two | tree
 %=
 1.23
 1.str()
+null
+nullo
 `
 
 	tests := []struct {
@@ -256,6 +258,8 @@ one | two | tree
 		{token.IDENT, "str"},
 		{token.LPAREN, "("},
 		{token.RPAREN, ")"},
+		{token.NULL, "null"},
+		{token.IDENT, "nullo"},
 		{token.EOF, ""},
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -82,6 +82,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.IDENT, p.parseIdentifier)
 	p.registerPrefix(token.NUMBER, p.parseNumberLiteral)
 	p.registerPrefix(token.STRING, p.ParseStringLiteral)
+	p.registerPrefix(token.NULL, p.ParseNullLiteral)
 	p.registerPrefix(token.BANG, p.parsePrefixExpression)
 	p.registerPrefix(token.MINUS, p.parsePrefixExpression)
 	p.registerPrefix(token.TRUE, p.parseBoolean)
@@ -350,6 +351,11 @@ func (p *Parser) parseNumberLiteral() ast.Expression {
 // "some"
 func (p *Parser) ParseStringLiteral() ast.Expression {
 	return &ast.StringLiteral{Token: p.curToken, Value: p.curToken.Literal}
+}
+
+// null
+func (p *Parser) ParseNullLiteral() ast.Expression {
+	return &ast.NullLiteral{Token: p.curToken}
 }
 
 // !x

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -976,6 +976,25 @@ func TestStringLiteralExpression(t *testing.T) {
 	}
 }
 
+func TestNullLiteralExpression(t *testing.T) {
+	input := `null;`
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	literal, ok := stmt.Expression.(*ast.NullLiteral)
+	if !ok {
+		t.Fatalf("exp not *ast.NullLiteral. got=%T", stmt.Expression)
+	}
+
+	if literal.TokenLiteral() != "null" {
+		t.Errorf("literal.Value not %q. got=%s", "null", literal.TokenLiteral())
+	}
+}
+
 func TestParsingEmptyArrayLiterals(t *testing.T) {
 	input := "[]"
 

--- a/token/token.go
+++ b/token/token.go
@@ -11,6 +11,7 @@ const (
 	NUMBER  = "NUMBER" // 1343456, 1.23456
 	STRING  = "STRING" // "foobar"
 	COMMENT = "#"      // # Comment
+	NULL    = "NULL"   // # null
 
 	// Operators
 	TILDE         = "~"
@@ -84,6 +85,7 @@ var keywords = map[string]TokenType{
 	"while":  WHILE,
 	"for":    FOR,
 	"in":     IN,
+	"null":   NULL,
 }
 
 func LookupIdent(ident string) TokenType {


### PR DESCRIPTION
This PR allows parsing JSON strings with NULL values.
The issue stems from the fact that you cannot assign
null values, as the string `null` is treated like any
random identifier.

This PR adds a NULL value in ABS, allowing to set a variable
to NULL:

```
x = null
x # null
```

Through that, JSON parsing of null values will work
out of the box.

This closes #85 