### PR TITLE
Removed scientific notation when printing out numbers

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -32,6 +32,7 @@ func TestEvalNumberExpression(t *testing.T) {
 		expected float64
 	}{
 		{"5.5", 5.5},
+		{"1.1 + 2.1", 3.2},
 		{"5.5 + 2.2", 7.7},
 		{"5", 5},
 		{"10", 10},
@@ -79,6 +80,9 @@ func TestEvalStringExpression(t *testing.T) {
 		input    string
 		expected string
 	}{
+		{"9999999999.str()", "9999999999"},
+		{"12.1.str()", "12.1"},
+		{"12.123456789.str()", "12.123456789"},
 		{`"5"`, "5"},
 		{`"5" + "5"`, "55"},
 	}

--- a/object/object.go
+++ b/object/object.go
@@ -3,6 +3,7 @@ package object
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/abs-lang/abs/ast"
@@ -51,8 +52,18 @@ type Number struct {
 	Value float64
 }
 
-func (n *Number) Type() ObjectType   { return NUMBER_OBJ }
-func (n *Number) Inspect() string    { return fmt.Sprintf("%v", n.Value) }
+func (n *Number) Type() ObjectType { return NUMBER_OBJ }
+
+// If the number we're dealing with is
+// an integer, print it as such (1.0000 becomes 1).
+// If it's a float, let's remove as many zeroes
+// as possible (1.10000 becomes 1.1).
+func (n *Number) Inspect() string {
+	if n.Value == float64(int64(n.Value)) {
+		return fmt.Sprintf("%d", int64(n.Value))
+	}
+	return strconv.FormatFloat(n.Value, 'f', -1, 64)
+}
 func (n *Number) ZeroValue() float64 { return float64(0) }
 func (n *Number) Int() int           { return int(n.Value) }
 


### PR DESCRIPTION
closes #89

This PR makes sure that numbers are formatted in a human
readable way.

* `1.000` becomes `1`
* `1.100` becomes `1.1`

Earlier on we used fmt's `%v` option, which default to scientific
notation for large floats.