### PR TITLE
Added bitwise operators, closes #84

### DIFF
--- a/docs/syntax/operators.md
+++ b/docs/syntax/operators.md
@@ -215,16 +215,6 @@ Range operator, which creates an array from start to end:
 1..10 # [1, 2, 3, 4, 5, 6, 7, 8, 9]
 ```
 
-## ~
-
-The tilde (meaning "around") is used to do a case-insensitive
-comparison between strings:
-
-``` bash
-"hello" == "HELLO" # false
-"hello" ~ "HELLO" # true
-```
-
 ## !
 
 Negation:
@@ -244,6 +234,69 @@ Even though there is no double negation operator, using
 !!0 # false
 !!"" # false
 !!"hello" # true
+```
+
+## ~
+
+The tilde (meaning "around") is used to do a case-insensitive
+comparison between strings:
+
+``` bash
+"hello" == "HELLO" # false
+"hello" ~ "HELLO" # true
+```
+
+When in front of a number, it will instead be used as a
+bitwise NOT:
+
+``` bash
+~0 # -1
+~"hello" # ERROR: Bitwise not (~) can only be applied to numbers, got STRING (hello)
+```
+
+## &
+
+Bitwise AND:
+
+``` bash
+1 & 1 # 1
+1 & "hello" # ERROR: type mismatch: NUMBER & STRING
+```
+
+## |
+
+Bitwise OR:
+
+``` bash
+1 | 1 # 1
+1 | "hello" # ERROR: type mismatch: NUMBER | STRING
+```
+
+## ^
+
+Bitwise XOR:
+
+``` bash
+1 ^ 1 # 0
+1 ^ "hello" # ERROR: type mismatch: NUMBER ^ STRING
+```
+
+## >>
+
+Bitwise right shift:
+
+``` bash
+1 >> 1 # 0
+1 >> "hello" # ERROR: type mismatch: NUMBER >> STRING
+```
+
+## <<
+
+Bitwise left shift:
+
+``` bash
+1 << 1 # 2
+1 << "hello" # ERROR: type mismatch: NUMBER << STRING
 ```
 
 ## Next

--- a/docs/types/number.md
+++ b/docs/types/number.md
@@ -21,6 +21,15 @@ a value that evaluates to `false` when casted to boolean:
 !!0 # false
 ```
 
+You can use [bitwise operators](/syntax/operators) on numbers, but bear in
+mind that they will be implicitely converted to integers:
+
+``` bash
+1 ^ 1 # 0
+1 ^ 0 # 1
+1 ^ 0.9 # 1, as 0.9 is converted to 0
+```
+
 ## Supported functions
 
 ### number()

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -262,6 +262,8 @@ func evalPrefixExpression(operator string, right object.Object) object.Object {
 		return evalBangOperatorExpression(right)
 	case "-":
 		return evalMinusPrefixOperatorExpression(right)
+	case "~":
+		return evalTildePrefixOperatorExpression(right)
 	default:
 		return newError("unknown operator: %s%s", operator, right.Type())
 	}
@@ -343,6 +345,15 @@ func evalBangOperatorExpression(right object.Object) object.Object {
 	}
 }
 
+func evalTildePrefixOperatorExpression(right object.Object) object.Object {
+	switch o := right.(type) {
+	case *object.Number:
+		return &object.Number{Value: float64(^int64(o.Value))}
+	default:
+		return newError("Bitwise not (~) can only be applied to numbers, got %s (%s)", o.Type(), o.Inspect())
+	}
+}
+
 func evalMinusPrefixOperatorExpression(right object.Object) object.Object {
 	if right.Type() != object.NUMBER_OBJ {
 		return newError("unknown operator: -%s", right.Type())
@@ -397,6 +408,16 @@ func evalNumberInfixExpression(
 		return nativeBoolToBooleanObject(leftVal == rightVal)
 	case "!=":
 		return nativeBoolToBooleanObject(leftVal != rightVal)
+	case "&":
+		return &object.Number{Value: float64(int64(leftVal) & int64(rightVal))}
+	case "|":
+		return &object.Number{Value: float64(int64(leftVal) | int64(rightVal))}
+	case ">>":
+		return &object.Number{Value: float64(uint64(leftVal) >> uint64(rightVal))}
+	case "<<":
+		return &object.Number{Value: float64(uint64(leftVal) << uint64(rightVal))}
+	case "^":
+		return &object.Number{Value: float64(int64(leftVal) ^ int64(rightVal))}
 	// A range results in an array of integers from left to right
 	case "..":
 		a := make([]object.Object, 0)

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -212,35 +212,55 @@ func TestForExpressions(t *testing.T) {
 	}
 }
 
-// func TestBitwiseExpressions(t *testing.T) {
-// 	tests := []struct {
-// 		input    string
-// 		expected interface{}
-// 	}{
-// 		{"1 & 1", 1},
-// 		{"1 & 1.1", 1},
-// 		{"1 & 0", 0},
-// 		{`1 & ""`, "ERROR"},
-// 	}
+func TestBitwiseExpressions(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{"1 & 1", 1},
+		{"1 & 1.1", 1},
+		{"1 & 0", 0},
+		{`1 & ""`, "type mismatch: NUMBER & STRING"},
+		{"1 ^ 1", 0},
+		{"1 ^ 1.1", 0},
+		{"1 ^ 0", 1},
+		{`1 ^ ""`, "type mismatch: NUMBER ^ STRING"},
+		{"1 | 1", 1},
+		{"1 | 1.1", 1},
+		{"1 | 0", 1},
+		{`1 | ""`, "type mismatch: NUMBER | STRING"},
+		{"1 >> 1", 0},
+		{"1 >> 1.1", 0},
+		{"1 >> 0", 1},
+		{`1 >> ""`, "type mismatch: NUMBER >> STRING"},
+		{"1 << 1", 2},
+		{"1 << 1.1", 2},
+		{"1 << 0", 1},
+		{`1 << ""`, "type mismatch: NUMBER << STRING"},
+		{"~1", -2},
+		{"~1.1", -2},
+		{"~0", -1},
+		{`~"abc"`, "Bitwise not (~) can only be applied to numbers, got STRING (abc)"},
+	}
 
-// 	for _, tt := range tests {
-// 		evaluated := testEval(tt.input)
-// 		integer, ok := tt.expected.(int)
-// 		if ok {
-// 			testNumberObject(t, evaluated, float64(integer))
-// 		} else {
-// 			errObj, ok := evaluated.(*object.Error)
-// 			if !ok {
-// 				t.Errorf("no error object returned. got=%T(%+v)", evaluated, evaluated)
-// 				continue
-// 			}
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+		integer, ok := tt.expected.(int)
+		if ok {
+			testNumberObject(t, evaluated, float64(integer))
+		} else {
+			errObj, ok := evaluated.(*object.Error)
+			if !ok {
+				t.Errorf("no error object returned. got=%T(%+v)", evaluated, evaluated)
+				continue
+			}
 
-// 			if errObj.Message != tt.expected {
-// 				t.Errorf("wrong error message. expected=%q, got=%q", tt.expected, errObj.Message)
-// 			}
-// 		}
-// 	}
-// }
+			if errObj.Message != tt.expected {
+				t.Errorf("wrong error message. expected=%q, got=%q", tt.expected, errObj.Message)
+			}
+		}
+	}
+}
 
 func TestForInExpressions(t *testing.T) {
 	tests := []struct {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -90,8 +90,10 @@ func (l *Lexer) NextToken() token.Token {
 			tok.Type = token.AND
 			tok.Literal = l.readLogicalOperator()
 		} else {
-			tok = newToken(token.ILLEGAL, l.ch)
+			tok = newToken(token.BIT_AND, l.ch)
 		}
+	case '^':
+		tok = newToken(token.BIT_XOR, l.ch)
 	case '*':
 		if l.peekChar() == '*' {
 			l.readChar()
@@ -122,6 +124,10 @@ func (l *Lexer) NextToken() token.Token {
 				tok.Type = token.LT_EQ
 				tok.Literal = "<="
 			}
+		} else if l.peekChar() == '<' {
+			tok.Type = token.BIT_LSHIFT
+			tok.Literal = "<<"
+			l.readChar()
 		} else {
 			tok = newToken(token.LT, l.ch)
 		}
@@ -129,6 +135,10 @@ func (l *Lexer) NextToken() token.Token {
 		if l.peekChar() == '=' {
 			tok.Type = token.GT_EQ
 			tok.Literal = ">="
+			l.readChar()
+		} else if l.peekChar() == '>' {
+			tok.Type = token.BIT_RSHIFT
+			tok.Literal = ">>"
 			l.readChar()
 		} else {
 			tok = newToken(token.GT, l.ch)

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -70,6 +70,7 @@ one | two | tree
 1.str()
 null
 nullo
+&^>><<
 `
 
 	tests := []struct {
@@ -260,6 +261,10 @@ nullo
 		{token.RPAREN, ")"},
 		{token.NULL, "null"},
 		{token.IDENT, "nullo"},
+		{token.BIT_AND, "&"},
+		{token.BIT_XOR, "^"},
+		{token.BIT_RSHIFT, ">>"},
+		{token.BIT_LSHIFT, "<<"},
 		{token.EOF, ""},
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -27,6 +27,11 @@ const (
 var precedences = map[token.TokenType]int{
 	token.AND:           AND,
 	token.OR:            AND,
+	token.BIT_AND:       AND,
+	token.BIT_XOR:       AND,
+	token.BIT_RSHIFT:    AND,
+	token.BIT_LSHIFT:    AND,
+	token.PIPE:          AND,
 	token.EQ:            EQUALS,
 	token.NOT_EQ:        EQUALS,
 	token.TILDE:         EQUALS,
@@ -53,7 +58,6 @@ var precedences = map[token.TokenType]int{
 	token.LPAREN:        CALL,
 	token.LBRACKET:      INDEX,
 	token.DOT:           DOT,
-	token.PIPE:          DOT,
 }
 
 type (
@@ -85,6 +89,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.NULL, p.ParseNullLiteral)
 	p.registerPrefix(token.BANG, p.parsePrefixExpression)
 	p.registerPrefix(token.MINUS, p.parsePrefixExpression)
+	p.registerPrefix(token.TILDE, p.parsePrefixExpression)
 	p.registerPrefix(token.TRUE, p.parseBoolean)
 	p.registerPrefix(token.FALSE, p.parseBoolean)
 	p.registerPrefix(token.LPAREN, p.parseGroupedExpression)
@@ -99,7 +104,6 @@ func New(l *lexer.Lexer) *Parser {
 
 	p.infixParseFns = make(map[token.TokenType]infixParseFn)
 	p.registerInfix(token.DOT, p.parseDottedExpression)
-	p.registerInfix(token.PIPE, p.parseMethodExpression)
 	p.registerInfix(token.PLUS, p.parseInfixExpression)
 	p.registerInfix(token.MINUS, p.parseInfixExpression)
 	p.registerInfix(token.SLASH, p.parseInfixExpression)
@@ -123,6 +127,11 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.COMBINED_COMP, p.parseInfixExpression)
 	p.registerInfix(token.AND, p.parseInfixExpression)
 	p.registerInfix(token.OR, p.parseInfixExpression)
+	p.registerInfix(token.BIT_AND, p.parseInfixExpression)
+	p.registerInfix(token.BIT_XOR, p.parseInfixExpression)
+	p.registerInfix(token.PIPE, p.parseInfixExpression)
+	p.registerInfix(token.BIT_RSHIFT, p.parseInfixExpression)
+	p.registerInfix(token.BIT_LSHIFT, p.parseInfixExpression)
 	p.registerInfix(token.RANGE, p.parseInfixExpression)
 	p.registerInfix(token.LPAREN, p.parseCallExpression)
 	p.registerInfix(token.LBRACKET, p.parseIndexExpression)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -908,18 +908,6 @@ func TestMethodExpressionParameterParsing(t *testing.T) {
 			expectedMethod: "method_name",
 			expectedArgs:   []string{"1"},
 		},
-		{
-			input:          "test | method(1, 2 * 3, 4 + 5);",
-			expectedObj:    "test",
-			expectedMethod: "method",
-			expectedArgs:   []string{"1", "(2 * 3)", "(4 + 5)"},
-		},
-		{
-			input:          "a | method_name(1);",
-			expectedObj:    "a",
-			expectedMethod: "method_name",
-			expectedArgs:   []string{"1"},
-		},
 	}
 
 	for _, tt := range tests {

--- a/token/token.go
+++ b/token/token.go
@@ -31,8 +31,19 @@ const (
 	COMP_MODULO   = "%="
 	RANGE         = ".."
 
+	// Logical operators
 	AND = "&&"
 	OR  = "OR"
+
+	// Bitwise operators
+	// It might be worth
+	// to rename these
+	// to AMPERSAND / CARET / etc
+	BIT_AND    = "&"
+	BIT_XOR    = "^"
+	BIT_RSHIFT = ">>"
+	BIT_LSHIFT = "<<"
+	PIPE       = "|"
 
 	LT            = "<"
 	LT_EQ         = "<="
@@ -55,7 +66,6 @@ const (
 	LBRACKET = "["
 	RBRACKET = "]"
 	DOT      = "."
-	PIPE     = "|"
 	COMMAND  = "$()"
 
 	// Keywords


### PR DESCRIPTION
```
⧐  1011 & 1011
1011
⧐  1011 | 1011
1011
⧐  1011 ^ 1011
0
⧐  1011 >> 1011
0
⧐  1011 << 1011
0
⧐  ~1011
-1012
```

With this change, the ability to call methods with the pipe
(`"str" | int()`) has been removed in order to make it easier
to implement the bitwise OR. Pipe calls were anyhow a dubious,
undocumented feature and were there mostly for vanity, to kind
of resemble unix pipes. Dotted calls are anyhow more concise:

```
"string" | split("i")

"string".split("i")
```

We might re-introduce piped calls at a later stage.