### PR TITLE
Fixed destructuring gotchas, closes #83

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ such as Python, or Ruby, to the convenience of Bash.
 
 ``` bash
 tz = $(cat /etc/timezone);
-[cont, city] = tz.split("/")
+continent, city = tz.split("/")
 
 echo("Best city in the world?")
 
@@ -31,7 +31,7 @@ if selection == city {
 
 See it in action:
 
-[![asciicast](https://asciinema.org/a/218451.svg)](https://asciinema.org/a/218451)
+[![asciicast](https://asciinema.org/a/218909.svg)](https://asciinema.org/a/218909)
 
 Let's try to fetch our IP address and print the sum of its
 parts, if its higher than 100. Here's how you could do it

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ such as Python, or Ruby, to the convenience of Bash.
 
 ``` bash
 tz = $(cat /etc/timezone);
-[cont, city] = tz.split("/")
+continent, city = tz.split("/")
 
 echo("Best city in the world?")
 
@@ -29,7 +29,7 @@ if selection == city {
 
 See it in action:
 
-[![asciicast](https://asciinema.org/a/218451.svg)](https://asciinema.org/a/218451)
+[![asciicast](https://asciinema.org/a/218909.svg)](https://asciinema.org/a/218909)
 
 Let's now try to fetch our IP address and print the sum of its
 parts, if its higher than 100. Here's how you could do it

--- a/docs/syntax/assignments.md
+++ b/docs/syntax/assignments.md
@@ -11,7 +11,7 @@ Array destructuring is supported, meaning you can
 set multiple variables based on an array:
 
 ``` bash
-[x, y, z] = ["hello world", 99, {}]
+x, y, z = ["hello world", 99, {}]
 x # "hello world"
 y # 99
 z # {}
@@ -22,24 +22,9 @@ than the array, the extra variables will be set to
 null:
 
 ``` bash
-[x] = []
-x # null
+x, y = [1]
+y # null
 ```
-
-Note that when using destructuring, the previous line
-should end with a semicolon:
-
-``` bash
-# Ok
-x = "10";
-[a] = [100]
-
-# Not ok, the parser reads this `x = "10"[a]`
-x = "10"
-[a] = [100]
-```
-
-This behavior will be fixed soon (see [#83](https://github.com/abs-lang/abs/issues/83)).
 
 ABS doesn't have block-specific scopes, so any new variable
 declared in a block is automatically available outside as well:

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -227,7 +227,7 @@ func evalAssignment(as *ast.AssignStatement, env *object.Environment) object.Obj
 		env.Set(as.Name.Value, val)
 	}
 
-	// destructuring [x] = [1]
+	// destructuring x, y = [1, 2]
 	if len(as.Names) > 0 {
 		if val.Type() != object.ARRAY_OBJ {
 			return newError("wrong assignment, expected identifier or array destructuring, got %s (%s)", val.Type(), val.Inspect())

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -470,15 +470,17 @@ func TestAssignStatements(t *testing.T) {
 		{"a = 5 * 5; a;", 25},
 		{"a = 5; b = a; b;", 5},
 		{"a = 5; b = a; c = a + b + 5; c;", 15},
-		{"[a] = [10]; a;", 10},
-		{"[a] = 10; a;", "wrong assignment, expected identifier or array destructuring, got NUMBER (10)"},
-		{"[a, b, c] = [1]; a;", 1},
-		{"[a, b, c] = [1]; b;", nil},
+		{"a, b, c = [1]; a;", 1},
+		{"a, b, c = [1]; b;", nil},
+		{`a = 10 + 1 + 2
+b, c = [1, 2]; b`, 1},
+		{`a = 10 + 1 + 2
+		b, c = [1, 2]; a`, 13},
 		{`
-tz = $(echo "10/20");
-[a, b] = tz.split("/")
-a.int()
-		`, 10},
+		tz = $(echo "10/20")
+		a, b = tz.split("/")
+		a.int()
+				`, 10},
 	}
 
 	for _, tt := range tests {

--- a/examples/city_selector.abs
+++ b/examples/city_selector.abs
@@ -1,5 +1,5 @@
-tz = $(cat /etc/timezone);
-[cont, city] = tz.split("/")
+tz = $(cat /etc/timezone)
+cont, city = tz.split("/")
 
 echo("Best city in the world?")
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -18,7 +18,7 @@ func TestAssignStatements(t *testing.T) {
 		{"x = 5;", "x", 5},
 		{"y = true;", "y", true},
 		{"foobar = y;", "foobar", "y"},
-		{"[x, y] = [1, 2];", "", nil},
+		{"x, y = [1, 2];", "", nil},
 	}
 
 	for _, tt := range tests {

--- a/scripts/release.abs
+++ b/scripts/release.abs
@@ -45,7 +45,7 @@ if !rm.ok {
 }
 
 for platform in platforms {
-    [goos, goarch] = platform.split("/")
+    goos, goarch = platform.split("/")
     output_name = "abs-preview-2-" + goos + "-" + goarch
 
     if (goos == "windows") {


### PR DESCRIPTION
Opted to change the syntax of destructuring to not require
brackets.

``` bash
[x, y] = [...]

x, y = [...]
```

and that's about it. With this, destructuring statements don't
need to be preceded by a semicolon, making them less wonky.