### PR TITLE
Reset of iterables, closes #112

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -592,6 +592,10 @@ func evalForInExpression(
 
 	switch i := iterable.(type) {
 	case object.Iterable:
+		defer func() {
+			i.Reset()
+		}()
+
 		return loopIterable(i.Next, env, fie, 0)
 	case *object.Builtin:
 		if i.Next == nil {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -267,6 +267,7 @@ func TestForInExpressions(t *testing.T) {
 		input    string
 		expected interface{}
 	}{
+		{"a = 1..3; b = 0; c = 0; for x in a { b = x }; for x in a { c = x }; c", 3}, // See: https://github.com/abs-lang/abs/issues/112
 		{"a = 0; for k, x in 1 { a = a + 1}; a", "'1' is a NUMBER, not an iterable, cannot be used in for loop"},
 		{"a = 0; for k, x in 1..10 { a = a + 1}; a", 10},
 		{"a = 0; for x in 1 { a = a + 1}; a", "'1' is a NUMBER, not an iterable, cannot be used in for loop"},

--- a/object/object.go
+++ b/object/object.go
@@ -46,6 +46,7 @@ type Object interface {
 
 type Iterable interface {
 	Next(int) (int, Object)
+	Reset()
 }
 
 type Number struct {
@@ -174,6 +175,9 @@ func (ao *Array) Next(pos int) (int, Object) {
 	}
 
 	return -1, nil
+}
+func (ao *Array) Reset() {
+	ao.position = 0
 }
 func (ao *Array) Homogeneous() bool {
 	if ao.Empty() {


### PR DESCRIPTION
After looping through an iterable, we should reset it's position to `0`.
The implementation of array iteration is a bit funky in order to support `for x in stdin {}`, but this should be it.

This should solve #112 