### PR TITLE
Allowing strings with single quotes, closes #110

### DIFF
--- a/docs/types/string.md
+++ b/docs/types/string.md
@@ -6,16 +6,23 @@ value in ABS: considering that shell scripting
 is all about working around command outputs,
 we assume you will likely work a lot with them.
 
-Strings are enclosed by double quotes:
+Strings are enclosed by double or single quotes:
 
 ``` bash
 "hello world"
+'hello world'
 ```
 
 You can escape quotes with a simple backslash:
 
 ``` bash
 "I said: \"hello world\""
+```
+
+or use the other quote to ease escaping:
+
+``` bash
+'I said: "hello world"'
 ```
 
 Their individual characters can be accessed

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -83,8 +83,13 @@ func TestEvalStringExpression(t *testing.T) {
 		{"9999999999.str()", "9999999999"},
 		{"12.1.str()", "12.1"},
 		{"12.123456789.str()", "12.123456789"},
+		{`"nice 'escaping"`, "nice 'escaping"},
+		{`'nice "escaping"`, `nice "escaping"`},
+		{`'nice \'escaping`, `nice 'escaping`},
+		{`"nice \"escaping"`, `nice "escaping`},
 		{`"5"`, "5"},
-		{`"5" + "5"`, "55"},
+		{`'5'`, "5"},
+		{`'hello %s'.fmt("world")`, "hello world"},
 	}
 
 	for _, tt := range tests {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -176,7 +176,10 @@ func (l *Lexer) NextToken() token.Token {
 		tok = newToken(token.RPAREN, l.ch)
 	case '"':
 		tok.Type = token.STRING
-		tok.Literal = l.readString()
+		tok.Literal = l.readString('"')
+	case '\'':
+		tok.Type = token.STRING
+		tok.Literal = l.readString('\'')
 	case '$':
 		if l.peekChar() == '(' {
 			tok.Type = token.COMMAND
@@ -298,7 +301,7 @@ func (l *Lexer) readLogicalOperator() string {
 // To close a string with an escape
 // character ("\"), escape the escape
 // character itself ("\\").
-func (l *Lexer) readString() string {
+func (l *Lexer) readString(quote byte) string {
 	var chars []string
 	doubleEscape := false
 	for {
@@ -314,8 +317,8 @@ func (l *Lexer) readString() string {
 		// If we encounter a \, let's check whether
 		// we're trying to escape a ". If so, let's skip
 		// the / and add the " to the string.
-		if l.ch == '\\' && l.peekChar() == '"' {
-			chars = append(chars, string('"'))
+		if l.ch == '\\' && l.peekChar() == quote {
+			chars = append(chars, string(quote))
 			l.readChar()
 			continue
 		}
@@ -323,7 +326,7 @@ func (l *Lexer) readString() string {
 		// The string ends when we encounter a "
 		// and the character before that was not a \,
 		// or the \ was escaped as well ("string\\").
-		if (l.ch == '"' && (l.prevChar(2) != '\\' || doubleEscape)) || l.ch == 0 {
+		if (l.ch == quote && (l.prevChar(2) != '\\' || doubleEscape)) || l.ch == 0 {
 			break
 		}
 

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -72,6 +72,7 @@ null
 nullo
 &^>><<
 $111
+'123'
 `
 
 	tests := []struct {
@@ -267,6 +268,7 @@ $111
 		{token.BIT_RSHIFT, ">>"},
 		{token.BIT_LSHIFT, "<<"},
 		{token.ILLEGAL, "$111"},
+		{token.STRING, "123"},
 		{token.EOF, ""},
 	}
 


### PR DESCRIPTION
This makes it easier for people bumping into ABS
for the first time, as well as allows for easier escaping
with strings like `'"Hello", she said!'` which had
to be written with `"\"Hello\", she said!"`.