### PR TITLE
installer.sh updates

### DIFF
--- a/docs/installer.sh
+++ b/docs/installer.sh
@@ -1,6 +1,6 @@
 command -v uname >/dev/null || {
   echo >&2 'requires uname'
-	exit 1
+  exit 1
 }
 
 OS="linux"
@@ -16,7 +16,7 @@ elif [ "${OSTYPE:0:4}" = "msys" ]; then
 elif [ "${OSTYPE:0:7}" = "freebsd" ]; then
   OS="freebsd"
 else
-	OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+  OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 fi
 
 ARCH="386"

--- a/docs/installer.sh
+++ b/docs/installer.sh
@@ -1,19 +1,26 @@
+command -v uname >/dev/null || {
+  echo >&2 'requires uname'
+	exit 1
+}
+
 OS="linux"
 
-if [ "$OSTYPE" = "darwin" ]; then
-        OS="darwin"
-elif [ "$OSTYPE" = "cygwin"* ]; then
-        OS="windows"
-elif [ "$OSTYPE" = "win32" ]; then
-        OS="windows"
-elif [ "$OSTYPE" = "msys" ]; then
-        OS="windows"
-elif [ "$OSTYPE" = "freebsd" ]; then
-        OS="freebds"
+if [ "${OSTYPE:0:6}" = "darwin" ]; then
+  OS="darwin"
+elif [ "${OSTYPE:0:6}" = "cygwin" ]; then
+  OS="windows"
+elif [ "${OSTYPE:0:5}" = "win32" ]; then
+  OS="windows"
+elif [ "${OSTYPE:0:4}" = "msys" ]; then
+  OS="windows"
+elif [ "${OSTYPE:0:7}" = "freebsd" ]; then
+  OS="freebsd"
+else
+	OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 fi
 
 ARCH="386"
-MACHINE_TYPE=`uname -m`
+MACHINE_TYPE=$(uname -m)
 if [ "${MACHINE_TYPE}" = 'x86_64' ]; then
   ARCH="amd64"
 fi
@@ -23,14 +30,14 @@ echo ""
 echo "If these don't seem correct, head over to https://github.com/abs-lang/abs/releases"
 echo "and download the right binary for your architecture."
 echo ""
-echo "OS: $OS"
-echo "ARCH: $ARCH"
+echo "OS: ${OS}"
+echo "ARCH: ${ARCH}"
 echo ""
 echo "Are these correct? [y/N]"
 
 while read line
 do
-  INPUT=$(echo $line | awk '{print toupper($0)}')
+  INPUT=$(echo ${line} | awk '{print toupper($0)}')
   if [ "${INPUT}" = "Y" ]; then
     break
   fi
@@ -39,12 +46,12 @@ do
 done < "/dev/stdin"
 
 VERSION=preview-3
-BIN=abs-$VERSION-$OS-$ARCH
-wget https://github.com/abs-lang/abs/releases/download/$VERSION/$BIN
-mv $BIN ./abs
+BIN=abs-${VERSION}-${OS}-${ARCH}
+wget https://github.com/abs-lang/abs/releases/download/${VERSION}/${BIN}
+mv ${BIN} ./abs
 chmod +x ./abs
 echo "\n"
 echo "ABS installation completed!\n"
 echo "You can start hacking by './abs script.abs'"
-echo "We recommend moving ABS into your \$PATH so that you can do 'abs ./script.abs' from any location.\n"
+echo "We recommend moving ABS into your \${PATH} so that you can do 'abs ./script.abs' from any location.\n"
 echo "If you just want to have a look around, run './abs' and you will enter the REPL."


### PR DESCRIPTION
confirm `uname` dependency.
limit length of `OSTYPE` for comparison.
add default if no `OSTYPE` matches.
standardize a few scripting best-practices, always `$()` and `${}`

abs-lang/abs#105