### PR TITLE
issue #38 v2: implementing token-based error location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ build:
 test:
 	# The -vet=off is as YOLO as it gets
 	go test ./... -vet=off
+test_verbose:
+	# this will show successful error [line:col] tests per #38
+	CONTEXT='abs' go test ./... -v -vet=off
 repl:
 	go run main.go
 build_simple:

--- a/docs/misc/error.md
+++ b/docs/misc/error.md
@@ -1,16 +1,58 @@
 # Errors
 
-When using ABS, you might bump into errors within your code:
-when the interpreter finds an error, it will give up trying
-to evaluate the script and will exit with status code `99`:
+When using ABS, you might bump into errors within your code. When the interpreter finds an error, it will give up trying to execute the script and will exit with status code `99`.
 
+Note that there are 2 phases of the interpreter: parser and evaluator.
+
+When the parser phase encounters a syntax error it will continue to process the rest of the file and report all of the syntax errors it finds. 
+
+However, the evaluator phase will quit immediately when it encounters an evaluation error. Thus, you may need to run the ABS interpreter multiple times to find all the run-time errors.
+
+When you are running ABS interactively in the Run, Eval, Print Loop (REPL) the location of the error can only be the current line you just entered.
+
+However, when you are running ABS over a script file (even a small one) locating errors requires more help from the interpreter. ABS now provides `[line:column]` positions as well as the error line itself following the error message.
+
+For example, a file with syntax errors might look like this when the first syntax error is in line 4 somewhere around column 11.
 ```
-$ cat examples/error.abs
+$ cat examples/error-parse.abs
+# there are multiple parser errors in this file
+
+# this is a malformed identifier
+m.a = 'abc'
+
+# this is a command terminated with a semi
+d/d = $(command);
+
+# this is a command terminated with a LF
+c/c = $(command)
+
+# this is a bad infix operator
+b %% c
+
+$ abs examples/error-parse.abs
+ parser errors:
+	no prefix parse function for '=' found
+	[4:11]	m.a = 'abc'
+	no prefix parse function for '=' found
+	[7:16]	d/d = $(command);
+	no prefix parse function for '=' found
+	[10:16]	c/c = $(command)
+	no prefix parse function for '%' found
+	[13:6]	b %% c
+
+$ echo $?
+99
+```
+Furthermore, a file with evaluation errors might look like this when the first error encountered is in line 2 somewhere around column 11:
+```
+$ cat examples/error-eval.abs
+# there is an evaluation error on line 2
 1 + "hello"
 echo("should not reach here")
 
-$ abs examples/error.abs
+$ abs examples/error-eval.abs
 ERROR: type mismatch: NUMBER + STRING
+	[2:11]	1 + "hello"
 
 $ echo $?
 99

--- a/docs/misc/technical-details.md
+++ b/docs/misc/technical-details.md
@@ -1,16 +1,12 @@
 # A few technical details...
 
-The ABS interpreter is built with Golang version `1.11`, and is mostly based
-on [the interpreter book](https://interpreterbook.com/) written by
-[Thorsten Ball](https://twitter.com/thorstenball).
+The ABS interpreter is built with Golang version `1.11`, and is mostly based on [the interpreter book](https://interpreterbook.com/) written by [Thorsten Ball](https://twitter.com/thorstenball).
 
-ABS is extremely different from Monkey, the "fictional" language the reader
-builds throughout the book, but the base structure (lexer, parser, evaluator)
-are still very much based on Thorsten's work.
+ABS is extremely different from Monkey, the "fictional" language the reader builds throughout the book, but the base structure (lexer, parser, evaluator) are still very much based on Thorsten's work.
 
 ## Why Go?
 
-There are multiple rasons Go's the ideal choice for ABS, in no
+There are multiple reasons Go is the ideal choice for ABS, in no
 particular order:
 
 * portability, as our goal is to be able to deliver ABS to
@@ -34,6 +30,71 @@ will probably work perfectly).
 With `make run` you can get inside a container built for ABS'
 development, and `make test` will run all tests.
 
+## Testing
+You can run the interpreter error location tests by invoking this bash script: `tests/test-abs.sh`.
+```
+$ tests/test-abs.sh
+
+=======================================
+Test Parser
+tests/test-parser.abs
+ parser errors:
+	no prefix parse function for '=' found
+	[4:11]	m.a = 'abc'
+	no prefix parse function for '=' found
+	[7:16]	d/d = $(command);
+	no prefix parse function for '=' found
+	[10:16]	c/c = $(command)
+	no prefix parse function for '%' found
+	[13:6]	b %% c
+	no prefix parse function for '&&' found
+	[22:4]	&&||!-/*5;
+	no prefix parse function for 'OR' found
+	[22:5]	&&||!-/*5;
+	no prefix parse function for '/' found
+	[22:8]	&&||!-/*5;
+	no prefix parse function for '<=>' found
+	[25:3]	<=>
+	expected next token to be ], got , instead
+	[44:3]	[1, 2];
+	no prefix parse function for ',' found
+	[44:5]	[1, 2];
+	no prefix parse function for ']' found
+	[44:7]	[1, 2];
+	no prefix parse function for '%' found
+	[68:2]	~%
+	no prefix parse function for '-=' found
+	[70:2]	-=
+	no prefix parse function for '/=' found
+	[72:2]	/=
+	no prefix parse function for '%=' found
+	[74:2]	%=
+	no prefix parse function for '^' found
+	[79:4]	&^>><<
+	no prefix parse function for '<<' found
+	[79:6]	&^>><<
+	Illegal token '$111'
+	[80:4]	$111
+	no prefix parse function for 'ILLEGAL' found
+	[76:7]	1.str()
+Exit code: 99
+
+=======================================
+Test Eval()
+tests/test-eval.abs
+ERROR: type mismatch: STRING + NUMBER
+	[8:35]	    s = s + 1   # this is a comment
+Exit code: 99
+
+ERROR: invalid property 'junk' on type ARRAY
+	[14:6]	    a.junk
+Exit code: 99
+
+ERROR: index operator not supported: f(x) {x} on HASH
+	[19:29]	    {"name": "Abs"}[f(x) {x}];  
+Exit code: 99
+
+```
 ## Roadmap
 
 We're currently working on the [preview-4](https://github.com/abs-lang/abs/milestone/7).

--- a/examples/error-eval.abs
+++ b/examples/error-eval.abs
@@ -1,0 +1,3 @@
+# there is an evaluation error on line 2
+1 + "hello"
+echo("should not reach here")

--- a/examples/error-parse.abs
+++ b/examples/error-parse.abs
@@ -1,0 +1,13 @@
+# there are multiple parser errors in this file
+
+# this is a malformed identifier
+m.a = 'abc'
+
+# this is a command terminated with a semi
+d/d = $(command);
+
+# this is a command terminated with a LF
+c/c = $(command)
+
+# this is a bad infix operator
+b %% c

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -11,16 +11,68 @@ type Lexer struct {
 	position     int  // current position in input (points to current char)
 	readPosition int  // current reading position in input (after current char)
 	ch           byte // current char under examination
+	// map of input line boundaries used by linePosition() for error location
+	lineMap [][2]int // array of [begin, end] pairs: [[0,12], [13,22], [23,33] ... ]
 }
 
 func New(input string) *Lexer {
 	l := &Lexer{input: input}
+	// map the input line boundaries for CurrentLine()
+	l.buildLineMap()
+	// read the first char
 	l.readChar()
 	return l
 }
 
+// buildLineMap creates map of input line boundaries used by LinePosition() for error location
+func (l *Lexer) buildLineMap() {
+	begin := 0
+	idx := 0
+	for i, ch := range l.input {
+		idx = i
+		if ch == '\n' {
+			l.lineMap = append(l.lineMap, [2]int{begin, idx})
+			begin = idx + 1
+		}
+	}
+	// last line
+	l.lineMap = append(l.lineMap, [2]int{begin, idx + 1})
+}
+
+// CurrentPosition returns l.position
 func (l *Lexer) CurrentPosition() int {
 	return l.position
+}
+
+// linePosition (pos) returns lineNum, begin, end
+func (l *Lexer) linePosition(pos int) (int, int, int) {
+	idx := 0
+	begin := 0
+	end := 0
+	for i, tuple := range l.lineMap {
+		idx = i
+		begin, end = tuple[0], tuple[1]
+		if pos >= begin && pos <= end {
+			break
+		}
+	}
+	lineNum := idx + 1
+	return lineNum, begin, end
+}
+
+// ErrorLine (pos) returns lineNum, column, errorLine
+func (l *Lexer) ErrorLine(pos int) (int, int, string) {
+	lineNum, begin, end := l.linePosition(pos)
+	errorLine := l.input[begin:end]
+	column := pos - begin + 1
+	return lineNum, column, errorLine
+}
+
+func (lex *Lexer) newToken(tokenType token.TokenType) token.Token {
+	return token.Token{
+		Type:     tokenType,
+		Position: lex.position,
+		Literal:  string(lex.ch)}
 }
 
 func (l *Lexer) NextToken() token.Token {
@@ -31,86 +83,100 @@ func (l *Lexer) NextToken() token.Token {
 	switch l.ch {
 	case '=':
 		if l.peekChar() == '=' {
+			tok = l.newToken(token.EQ)
 			ch := l.ch
 			l.readChar()
 			literal := string(ch) + string(l.ch)
-			tok = token.Token{Type: token.EQ, Literal: literal}
+			tok.Literal = literal
+			// tok = token.Token{Type: token.EQ, Literal: literal}
 		} else {
-			tok = newToken(token.ASSIGN, l.ch)
+			tok = l.newToken(token.ASSIGN)
 		}
 	case '+':
 		if l.peekChar() == '=' {
 			tok.Type = token.COMP_PLUS
+			tok.Position = l.position
 			tok.Literal = "+="
 			l.readChar()
 		} else {
-			tok = newToken(token.PLUS, l.ch)
+			tok = l.newToken(token.PLUS)
 		}
 	case '-':
 		if l.peekChar() == '=' {
 			tok.Type = token.COMP_MINUS
+			tok.Position = l.position
 			tok.Literal = "-="
 			l.readChar()
 		} else {
-			tok = newToken(token.MINUS, l.ch)
+			tok = l.newToken(token.MINUS)
 		}
 	case '%':
 		if l.peekChar() == '=' {
 			tok.Type = token.COMP_MODULO
+			tok.Position = l.position
 			tok.Literal = "%="
 			l.readChar()
 		} else {
-			tok = newToken(token.MODULO, l.ch)
+			tok = l.newToken(token.MODULO)
 		}
 	case '!':
 		if l.peekChar() == '=' {
+			tok = l.newToken(token.NOT_EQ)
 			ch := l.ch
 			l.readChar()
 			literal := string(ch) + string(l.ch)
-			tok = token.Token{Type: token.NOT_EQ, Literal: literal}
+			tok.Literal = literal
+			// tok = token.Token{Type: token.NOT_EQ, Literal: literal}
 		} else {
-			tok = newToken(token.BANG, l.ch)
+			tok = l.newToken(token.BANG)
 		}
 	case '/':
 		if l.peekChar() == '/' {
 			tok.Type = token.COMMENT
+			tok.Position = l.position
 			tok.Literal = l.readLine()
 		} else if l.peekChar() == '=' {
 			tok.Type = token.COMP_SLASH
+			tok.Position = l.position
 			tok.Literal = "/="
 			l.readChar()
 		} else {
-			tok = newToken(token.SLASH, l.ch)
+			tok = l.newToken(token.SLASH)
 		}
 	case '#':
 		tok.Type = token.COMMENT
+		tok.Position = l.position
 		tok.Literal = l.readLine()
 	case '&':
 		if l.peekChar() == '&' {
 			tok.Type = token.AND
+			tok.Position = l.position
 			tok.Literal = l.readLogicalOperator()
 		} else {
-			tok = newToken(token.BIT_AND, l.ch)
+			tok = l.newToken(token.BIT_AND)
 		}
 	case '^':
-		tok = newToken(token.BIT_XOR, l.ch)
+		tok = l.newToken(token.BIT_XOR)
 	case '*':
 		if l.peekChar() == '*' {
 			l.readChar()
 			if l.peekChar() == '=' {
 				tok.Type = token.COMP_EXPONENT
+				tok.Position = l.position
 				tok.Literal = "**="
 				l.readChar()
 			} else {
 				tok.Type = token.EXPONENT
+				tok.Position = l.position
 				tok.Literal = "**"
 			}
 		} else if l.peekChar() == '=' {
 			tok.Type = token.COMP_ASTERISK
+			tok.Position = l.position
 			tok.Literal = "*="
 			l.readChar()
 		} else {
-			tok = newToken(token.ASTERISK, l.ch)
+			tok = l.newToken(token.ASTERISK)
 		}
 	case '<':
 		if l.peekChar() == '=' {
@@ -118,95 +184,109 @@ func (l *Lexer) NextToken() token.Token {
 
 			if l.peekChar() == '>' {
 				tok.Type = token.COMBINED_COMP
+				tok.Position = l.position
 				tok.Literal = "<=>"
 				l.readChar()
 			} else {
 				tok.Type = token.LT_EQ
+				tok.Position = l.position
 				tok.Literal = "<="
 			}
 		} else if l.peekChar() == '<' {
 			tok.Type = token.BIT_LSHIFT
+			tok.Position = l.position
 			tok.Literal = "<<"
 			l.readChar()
 		} else {
-			tok = newToken(token.LT, l.ch)
+			tok = l.newToken(token.LT)
 		}
 	case '>':
 		if l.peekChar() == '=' {
 			tok.Type = token.GT_EQ
+			tok.Position = l.position
 			tok.Literal = ">="
 			l.readChar()
 		} else if l.peekChar() == '>' {
 			tok.Type = token.BIT_RSHIFT
+			tok.Position = l.position
 			tok.Literal = ">>"
 			l.readChar()
 		} else {
-			tok = newToken(token.GT, l.ch)
+			tok = l.newToken(token.GT)
 		}
 	case ';':
-		tok = newToken(token.SEMICOLON, l.ch)
+		tok = l.newToken(token.SEMICOLON)
 	case ':':
-		tok = newToken(token.COLON, l.ch)
+		tok = l.newToken(token.COLON)
 	case ',':
-		tok = newToken(token.COMMA, l.ch)
+		tok = l.newToken(token.COMMA)
 	case '.':
 		if l.peekChar() == '.' {
 			tok.Type = token.RANGE
+			tok.Position = l.position
 			tok.Literal = ".."
 			l.readChar()
 		} else {
-			tok = newToken(token.DOT, l.ch)
+			tok = l.newToken(token.DOT)
 		}
 	case '|':
 		if l.peekChar() == '|' {
 			tok.Type = token.OR
+			tok.Position = l.position
 			tok.Literal = l.readLogicalOperator()
 		} else {
-			tok = newToken(token.PIPE, l.ch)
+			tok = l.newToken(token.PIPE)
 		}
 	case '{':
-		tok = newToken(token.LBRACE, l.ch)
+		tok = l.newToken(token.LBRACE)
 	case '}':
-		tok = newToken(token.RBRACE, l.ch)
+		tok = l.newToken(token.RBRACE)
 	case '~':
-		tok = newToken(token.TILDE, l.ch)
+		tok = l.newToken(token.TILDE)
 	case '(':
-		tok = newToken(token.LPAREN, l.ch)
+		tok = l.newToken(token.LPAREN)
 	case ')':
-		tok = newToken(token.RPAREN, l.ch)
+		tok = l.newToken(token.RPAREN)
 	case '"':
 		tok.Type = token.STRING
+		tok.Position = l.position
 		tok.Literal = l.readString('"')
 	case '\'':
 		tok.Type = token.STRING
+		tok.Position = l.position
 		tok.Literal = l.readString('\'')
 	case '$':
 		if l.peekChar() == '(' {
 			tok.Type = token.COMMAND
+			tok.Position = l.position
 			tok.Literal = l.readCommand()
 		} else {
 			tok.Type = token.ILLEGAL
+			tok.Position = l.position
 			tok.Literal = l.readLine()
 		}
 	case '[':
-		tok = newToken(token.LBRACKET, l.ch)
+		tok = l.newToken(token.LBRACKET)
 	case ']':
-		tok = newToken(token.RBRACKET, l.ch)
+		tok = l.newToken(token.RBRACKET)
 	case 0:
-		tok.Literal = ""
 		tok.Type = token.EOF
+		tok.Position = l.position
+		tok.Literal = ""
 	default:
 		if isLetter(l.ch) {
+			tok.Position = l.position
 			tok.Literal = l.readIdentifier()
 			tok.Type = token.LookupIdent(tok.Literal)
 			return tok
 		} else if isDigit(l.ch) {
+			tok.Position = l.position
 			literal, kind := l.readNumber()
 			tok.Type = kind
 			tok.Literal = literal
 			return tok
 		} else {
-			tok = newToken(token.ILLEGAL, l.ch)
+			tok = l.newToken(token.ILLEGAL)
 		}
 	}
 
@@ -227,7 +307,7 @@ func (l *Lexer) readChar() {
 		l.ch = l.input[l.readPosition]
 	}
 	l.position = l.readPosition
-	l.readPosition += 1
+	l.readPosition++
 }
 
 func (l *Lexer) Rewind(pos int) {
@@ -373,7 +453,6 @@ func (l *Lexer) readCommand() string {
 			break
 		}
 	}
-
 	ret := l.input[position : l.position-subtract]
 
 	// Let's make sure the semicolo is the next token, without
@@ -392,8 +471,4 @@ func isLetter(ch byte) bool {
 
 func isDigit(ch byte) bool {
 	return '0' <= ch && ch <= '9'
-}
-
-func newToken(tokenType token.TokenType, ch byte) token.Token {
-	return token.Token{Type: tokenType, Literal: string(ch)}
 }

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -88,7 +88,6 @@ func (l *Lexer) NextToken() token.Token {
 			l.readChar()
 			literal := string(ch) + string(l.ch)
 			tok.Literal = literal
-			// tok = token.Token{Type: token.EQ, Literal: literal}
 		} else {
 			tok = l.newToken(token.ASSIGN)
 		}
@@ -126,7 +125,6 @@ func (l *Lexer) NextToken() token.Token {
 			l.readChar()
 			literal := string(ch) + string(l.ch)
 			tok.Literal = literal
-			// tok = token.Token{Type: token.NOT_EQ, Literal: literal}
 		} else {
 			tok = l.newToken(token.BANG)
 		}

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/abs-lang/abs/repl"
 )
 
-var VERSION = "latest"
+var VERSION = "preview-3"
 
 // The ABS interpreter
 func main() {

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/abs-lang/abs/repl"
 )
 
-var VERSION = "preview-3"
+var VERSION = "latest"
 
 // The ABS interpreter
 func main() {
@@ -21,17 +21,17 @@ func main() {
 
 	args := os.Args
 
+	if len(args) == 2 && args[1] == "--version" {
+		fmt.Println(VERSION)
+		return
+	}
+
 	// if we're called without arguments,
 	// launch the REPL
 	if len(args) == 1 || strings.HasPrefix(args[1], "-") {
 		fmt.Printf("Hello %s, welcome to the ABS programming language!\n", user.Username)
 		fmt.Printf("Type 'quit' when you're done, 'help' if you get lost!\n")
 		repl.Start(os.Stdin, os.Stdout)
-		return
-	}
-
-	if args[1] == "--version" {
-		fmt.Println(VERSION)
 		return
 	}
 

--- a/object/object.go
+++ b/object/object.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/abs-lang/abs/ast"
+	"github.com/abs-lang/abs/token"
 )
 
 type BuiltinFunction func(args ...Object) Object
@@ -31,6 +32,7 @@ const (
 )
 
 type HashKey struct {
+	Token token.Token
 	Type  ObjectType
 	Value string
 }
@@ -50,6 +52,7 @@ type Iterable interface {
 }
 
 type Number struct {
+	Token token.Token
 	Value float64
 }
 
@@ -69,18 +72,22 @@ func (n *Number) ZeroValue() float64 { return float64(0) }
 func (n *Number) Int() int           { return int(n.Value) }
 
 type Boolean struct {
+	Token token.Token
 	Value bool
 }
 
 func (b *Boolean) Type() ObjectType { return BOOLEAN_OBJ }
 func (b *Boolean) Inspect() string  { return fmt.Sprintf("%t", b.Value) }
 
-type Null struct{}
+type Null struct {
+	Token token.Token
+}
 
 func (n *Null) Type() ObjectType { return NULL_OBJ }
 func (n *Null) Inspect() string  { return "null" }
 
 type ReturnValue struct {
+	Token token.Token
 	Value Object
 }
 
@@ -95,6 +102,7 @@ func (e *Error) Type() ObjectType { return ERROR_OBJ }
 func (e *Error) Inspect() string  { return "ERROR: " + e.Message }
 
 type Function struct {
+	Token      token.Token
 	Parameters []*ast.Identifier
 	Body       *ast.BlockStatement
 	Env        *Environment
@@ -112,9 +120,9 @@ func (f *Function) Inspect() string {
 	out.WriteString("f")
 	out.WriteString("(")
 	out.WriteString(strings.Join(params, ", "))
-	out.WriteString(") {\n")
+	out.WriteString(") {")
 	out.WriteString(f.Body.String())
-	out.WriteString("\n}")
+	out.WriteString("}")
 
 	return out.String()
 }
@@ -140,6 +148,7 @@ func (f *Function) Inspect() string {
 // type(cmd) // STRING
 // cmd.ok // FALSE
 type String struct {
+	Token token.Token
 	Value string
 	Ok    *Boolean // A special property to check whether a command exited correctly
 }
@@ -152,6 +161,7 @@ func (s *String) HashKey() HashKey {
 }
 
 type Builtin struct {
+	Token    token.Token
 	Fn       BuiltinFunction
 	Next     func(int) (int, Object)
 	Types    []string
@@ -162,6 +172,7 @@ func (b *Builtin) Type() ObjectType { return BUILTIN_OBJ }
 func (b *Builtin) Inspect() string  { return "builtin function" }
 
 type Array struct {
+	Token    token.Token
 	Elements []Object
 	position int
 }
@@ -219,6 +230,7 @@ type HashPair struct {
 }
 
 type Hash struct {
+	Token token.Token
 	Pairs map[HashKey]HashPair
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -364,8 +364,7 @@ func (p *Parser) curPrecedence() int {
 
 // var
 func (p *Parser) parseIdentifier() ast.Expression {
-	id := &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
-	return id
+	return &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
 }
 
 // 1 or 1.1
@@ -386,14 +385,12 @@ func (p *Parser) parseNumberLiteral() ast.Expression {
 
 // "some"
 func (p *Parser) ParseStringLiteral() ast.Expression {
-	lit := &ast.StringLiteral{Token: p.curToken, Value: p.curToken.Literal}
-	return lit
+	return &ast.StringLiteral{Token: p.curToken, Value: p.curToken.Literal}
 }
 
 // null
 func (p *Parser) ParseNullLiteral() ast.Expression {
-	lit := &ast.NullLiteral{Token: p.curToken}
-	return lit
+	return &ast.NullLiteral{Token: p.curToken}
 }
 
 // !x

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -149,40 +149,47 @@ func (p *Parser) nextToken() {
 
 	if p.curTokenIs(token.ILLEGAL) {
 		msg := fmt.Sprintf(`Illegal token '%s'`, p.curToken.Literal)
-		p.errors = append(p.errors, msg)
+		p.reportError(msg, p.curToken)
 	}
 }
 
-func (p *Parser) curTokenIs(t token.TokenType) bool {
-	return p.curToken.Type == t
+func (p *Parser) curTokenIs(typ token.TokenType) bool {
+	return p.curToken.Type == typ
 }
 
-func (p *Parser) peekTokenIs(t token.TokenType) bool {
-	return p.peekToken.Type == t
+func (p *Parser) peekTokenIs(typ token.TokenType) bool {
+	return p.peekToken.Type == typ
 }
 
-func (p *Parser) expectPeek(t token.TokenType) bool {
-	if p.peekTokenIs(t) {
+func (p *Parser) expectPeek(typ token.TokenType) bool {
+	if p.peekTokenIs(typ) {
 		p.nextToken()
 		return true
-	} else {
-		p.peekError(t)
-		return false
 	}
+	p.peekError(p.curToken)
+	return false
 }
 
 func (p *Parser) Errors() []string {
 	return p.errors
 }
 
-func (p *Parser) peekError(t token.TokenType) {
-	msg := fmt.Sprintf("expected next token to be %s, got %s instead", t, p.peekToken.Type)
+func (p *Parser) reportError(err string, tok token.Token) {
+	// report error at token location
+	lineNum, column, errorLine := p.l.ErrorLine(tok.Position)
+	msg := fmt.Sprintf("%s\n\t[%d:%d]\t%s", err, lineNum, column, errorLine)
 	p.errors = append(p.errors, msg)
 }
 
-func (p *Parser) noPrefixParseFnError(t token.TokenType) {
-	msg := fmt.Sprintf("no prefix parse function for %s found", t)
-	p.errors = append(p.errors, msg)
+func (p *Parser) peekError(tok token.Token) {
+	msg := fmt.Sprintf("expected next token to be %s, got %s instead", tok.Type, p.peekToken.Type)
+	p.reportError(msg, tok)
+}
+
+func (p *Parser) noPrefixParseFnError(tok token.Token) {
+	msg := fmt.Sprintf("no prefix parse function for '%s' found", tok.Literal)
+	// match := fmt.Sprintf("%s", t)
+	p.reportError(msg, tok)
 }
 
 func (p *Parser) ParseProgram() *ast.Program {
@@ -196,7 +203,6 @@ func (p *Parser) ParseProgram() *ast.Program {
 		}
 		p.nextToken()
 	}
-
 	return program
 }
 
@@ -321,7 +327,7 @@ func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
 func (p *Parser) parseExpression(precedence int) ast.Expression {
 	prefix := p.prefixParseFns[p.curToken.Type]
 	if prefix == nil {
-		p.noPrefixParseFnError(p.curToken.Type)
+		p.noPrefixParseFnError(p.curToken)
 		return nil
 	}
 	leftExp := prefix()
@@ -358,7 +364,8 @@ func (p *Parser) curPrecedence() int {
 
 // var
 func (p *Parser) parseIdentifier() ast.Expression {
-	return &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+	id := &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+	return id
 }
 
 // 1 or 1.1
@@ -368,7 +375,7 @@ func (p *Parser) parseNumberLiteral() ast.Expression {
 	value, err := strconv.ParseFloat(p.curToken.Literal, 64)
 	if err != nil {
 		msg := fmt.Sprintf("could not parse %q as number", p.curToken.Literal)
-		p.errors = append(p.errors, msg)
+		p.reportError(msg, p.curToken)
 		return nil
 	}
 
@@ -379,12 +386,14 @@ func (p *Parser) parseNumberLiteral() ast.Expression {
 
 // "some"
 func (p *Parser) ParseStringLiteral() ast.Expression {
-	return &ast.StringLiteral{Token: p.curToken, Value: p.curToken.Literal}
+	lit := &ast.StringLiteral{Token: p.curToken, Value: p.curToken.Literal}
+	return lit
 }
 
 // null
 func (p *Parser) ParseNullLiteral() ast.Expression {
-	return &ast.NullLiteral{Token: p.curToken}
+	lit := &ast.NullLiteral{Token: p.curToken}
+	return lit
 }
 
 // !x
@@ -450,13 +459,13 @@ func (p *Parser) parseDottedExpression(object ast.Expression) ast.Expression {
 		exp.Method = p.parseExpression(precedence)
 		p.nextToken()
 		exp.Arguments = p.parseExpressionList(token.RPAREN)
-
 		return exp
 	} else {
 		exp := &ast.PropertyExpression{Token: t, Object: object}
 
 		if !p.curTokenIs(token.IDENT) {
-			p.errors = append(p.errors, fmt.Sprintf("property needs to be an identifier, got '%s'", p.curToken.Literal))
+			msg := fmt.Sprintf("property needs to be an identifier, got '%s'", p.curToken.Literal)
+			p.reportError(msg, p.curToken)
 		}
 
 		exp.Property = p.parseIdentifier()
@@ -477,7 +486,8 @@ func (p *Parser) parseMethodExpression(object ast.Expression) ast.Expression {
 
 // true
 func (p *Parser) parseBoolean() ast.Expression {
-	return &ast.Boolean{Token: p.curToken, Value: p.curTokenIs(token.TRUE)}
+	b := &ast.Boolean{Token: p.curToken, Value: p.curTokenIs(token.TRUE)}
+	return b
 }
 
 func (p *Parser) parseGroupedExpression() ast.Expression {
@@ -517,7 +527,6 @@ func (p *Parser) parseIfExpression() ast.Expression {
 
 		expression.Alternative = p.parseBlockStatement()
 	}
-
 	return expression
 }
 
@@ -535,7 +544,6 @@ func (p *Parser) parseWhileExpression() ast.Expression {
 	}
 
 	expression.Consequence = p.parseBlockStatement()
-
 	return expression
 }
 
@@ -777,7 +785,8 @@ func (p *Parser) ParseHashLiteral() ast.Expression {
 }
 
 func (p *Parser) parseCommand() ast.Expression {
-	return &ast.CommandExpression{Token: p.curToken, Value: p.curToken.Literal}
+	cmd := &ast.CommandExpression{Token: p.curToken, Value: p.curToken.Literal}
+	return cmd
 }
 
 // We don't really have to do anything when comments

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -96,16 +96,21 @@ func executor(line string) {
 // This function takes code and evaluates
 // it, spitting out the result.
 func Run(code string, interactive bool) {
-	l := lexer.New(code)
-	p := parser.New(l)
+	lex := lexer.New(code)
+	p := parser.New(lex)
 
 	program := p.ParseProgram()
 	if len(p.Errors()) != 0 {
 		printParserErrors(p.Errors())
+		if !interactive {
+			os.Exit(99)
+		}
 		return
 	}
 
-	evaluated := evaluator.Eval(program, env)
+	// invoke BeginEval() passing in the program, env, and lexer for error position
+	// NB. Eval(node, env) is recursive so we can't call it directly
+	evaluated := evaluator.BeginEval(program, env, lex)
 
 	if evaluated != nil {
 		isError := evaluated.Type() == object.ERROR_OBJ

--- a/tests/test-abs.sh
+++ b/tests/test-abs.sh
@@ -1,0 +1,36 @@
+#! /bin/bash
+# test the abs parser and eval error location
+
+DIR=~/go/src/github.com/abs-lang/abs
+ABS=$(command -v abs)
+
+DEBUG=$1
+
+if [[ "$DEBUG" == "-d" ]]; then
+    ABS=$DIR/builds/abs
+fi
+if [ -z $ABS ]; then
+    echo "Cannot locate abs binary; exiting"
+    exit 1
+fi
+
+cd $DIR
+LINE="======================================="
+echo $LINE
+echo "Test Parser"
+FILE=tests/test-parser.abs
+echo $FILE
+$ABS $FILE
+echo "Exit code: $?"
+echo
+
+echo $LINE
+echo "Test Eval()"
+FILE=tests/test-eval.abs
+echo $FILE
+
+for i in 1 2 3; do
+    $ABS $FILE $i
+    echo "Exit code: $?"
+    echo
+done

--- a/tests/test-eval.abs
+++ b/tests/test-eval.abs
@@ -1,0 +1,20 @@
+# eval fails
+
+test_num = int(arg(2))
+
+if test_num == 1 {
+    # mismatched type
+    s = "string"
+    s = s + 1   # this is a comment
+}
+
+if test_num == 2 {
+    # invalid property
+    a = [1,2,3]
+    a.junk
+}
+
+if test_num == 3 {
+    # invalid function as index
+    {"name": "Abs"}[f(x) {x}];  
+}

--- a/tests/test-parser.abs
+++ b/tests/test-parser.abs
@@ -1,0 +1,81 @@
+# parser fails
+
+# this is a malformed identifier
+m.a = 'abc'
+
+# this is a command terminated with a semi
+d/d = $(command);
+
+# this is a command terminated with a LF
+c/c = $(command)
+
+# this is a bad infix operator
+b %% c
+
+# test from lexer/lexer_test.go
+five = 5;
+ten = 10;
+add = f(x, y) {
+  x + y;
+};
+result = add(five, ten);
+&&||!-/*5;
+5 < 10 > 5;
+1 <= 1 >= 1;
+<=>
+if (5 < 10) {
+	return true;
+} else {
+	return false;
+}
+while (1 > 0) {
+	echo("hello")
+}
+for x in xs {
+	x
+}
+for x = 0; x < 10; x = x + 1 {
+	x
+}
+10 == 10;
+10 != 9;
+"foobar"
+"foo bar"
+[1, 2];
+$(echo "()");
+{"foo": "bar"}
+$(curl icanhazip.com -X POST)
+$(ls *.go);
+a = [1]
+a.first()
+a.prop
+# Comment
+// Comment
+hello
+$(command; command)
+$(command2; command2);
+one | two | tree
+"hel\"lo"
+"hel\lo"
+"hel\\\\lo"
+"\"hello\""
+"\"he\"\"llo\""
+"hello\\"
+"hello\\\\"
+"\\\\hello"
+**
+1..10
+~%
++=
+-=
+*=
+/=
+**=
+%=
+1.23
+1.str()
+null
+nullo
+&^>><<
+$111
+'123'

--- a/token/token.go
+++ b/token/token.go
@@ -1,5 +1,7 @@
 package token
 
+// import "github.com/abs-lang/abs/lexer"
+
 type TokenType string
 
 const (
@@ -33,7 +35,7 @@ const (
 
 	// Logical operators
 	AND = "&&"
-	OR  = "OR"
+	OR  = "||"
 
 	// Bitwise operators
 	// It might be worth
@@ -81,8 +83,9 @@ const (
 )
 
 type Token struct {
-	Type    TokenType
-	Literal string
+	Type     TokenType
+	Position int // lexer position in file before token
+	Literal  string
 }
 
 var keywords = map[string]TokenType{


### PR DESCRIPTION
Well, it turns out that any lexer.CurrentPosition() based approach is useless for error location because the lexer fast forward functions such as lexer.skipWhiteSpace(), lexer.readLine(), et al. change the current position before the interpreter reports the error. 

So, the new model does token-based position marking which is totally accurate (i.e. hack-free). In this model the lexer captures the current lexer.position in lexer.NextToken() (before it can move away) and saves it into the new Token.Position field. Since the parser already places the Token into each of the existing ast.Node.Token fields, we carry the token.Position along for the ride into the evaluator. And, as before, we pass the lexer pointer thru to the evaluator, but the REPL and testing modules now call a new BeginEval(node, *env, *lexer) function which, in turn, calls the recursive Eval(node, *env) function.

Thus, when we hit either a parser or evaluator error, their error location reporters pull the token.Location and pass it to the lexer.ErrorLine(pos) method which does the position look-up in the lexer.lineMap and returns the lineNum, column, and errorLine for formatting into the error location message.

Bottom line is that both the line numbers and columns are now accurate in both the parser and evaluator error messages without requiring any backtracking in the file.

I will withdraw the previous PR and, upon further review, we can go forward with this PR v2 instead.
