### PR TITLE
Allow `.json(...)` to be called on all types, closes #54

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -84,14 +84,14 @@ func New(l *lexer.Lexer) *Parser {
 
 	p.prefixParseFns = make(map[token.TokenType]prefixParseFn)
 	p.registerPrefix(token.IDENT, p.parseIdentifier)
-	p.registerPrefix(token.NUMBER, p.parseNumberLiteral)
+	p.registerPrefix(token.NUMBER, p.ParseNumberLiteral)
 	p.registerPrefix(token.STRING, p.ParseStringLiteral)
 	p.registerPrefix(token.NULL, p.ParseNullLiteral)
 	p.registerPrefix(token.BANG, p.parsePrefixExpression)
 	p.registerPrefix(token.MINUS, p.parsePrefixExpression)
 	p.registerPrefix(token.TILDE, p.parsePrefixExpression)
-	p.registerPrefix(token.TRUE, p.parseBoolean)
-	p.registerPrefix(token.FALSE, p.parseBoolean)
+	p.registerPrefix(token.TRUE, p.ParseBoolean)
+	p.registerPrefix(token.FALSE, p.ParseBoolean)
 	p.registerPrefix(token.LPAREN, p.parseGroupedExpression)
 	p.registerPrefix(token.IF, p.parseIfExpression)
 	p.registerPrefix(token.WHILE, p.parseWhileExpression)
@@ -368,7 +368,7 @@ func (p *Parser) parseIdentifier() ast.Expression {
 }
 
 // 1 or 1.1
-func (p *Parser) parseNumberLiteral() ast.Expression {
+func (p *Parser) ParseNumberLiteral() ast.Expression {
 	lit := &ast.NumberLiteral{Token: p.curToken}
 
 	value, err := strconv.ParseFloat(p.curToken.Literal, 64)
@@ -482,7 +482,7 @@ func (p *Parser) parseMethodExpression(object ast.Expression) ast.Expression {
 }
 
 // true
-func (p *Parser) parseBoolean() ast.Expression {
+func (p *Parser) ParseBoolean() ast.Expression {
 	return &ast.Boolean{Token: p.curToken, Value: p.curTokenIs(token.TRUE)}
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -1,5 +1,7 @@
 package util
 
+import "strconv"
+
 // Checks whether the element e is in the
 // list of strings s
 func Contains(s []string, e string) bool {
@@ -9,4 +11,10 @@ func Contains(s []string, e string) bool {
 		}
 	}
 	return false
+}
+
+func IsNumber(s string) bool {
+	_, err := strconv.ParseFloat(s, 64)
+
+	return err == nil
 }


### PR DESCRIPTION
```
⧐  type('{}'.json())
HASH
⧐  type('[]'.json())
ARRAY
⧐  type('"hello"'.json())
STRING
⧐  type('1'.json())
NUMBER
```

In this PR I had to revert some of the changes we made in the tests
earlier on. Using `strings.Contains` in the tests is very dangerous,
and I reverted back to equality for most tests -- with the exception
of the tests that check for error messages that use `strings.HasPrefix`
which should be a bit more robust. The problem with `strings.Contains`
is that is a tests expects a string (`"hello"`) and instead an error
is thrown (`"Unable to call function: hello"`) the test will silently
pass since it finds our expected string inside the error message. With
`strings.HasPrefix` we limit these cases considerably.

The end goal would be to make sure
we can actually differentiate when ABS returns a string and an error string,
but for now this is something we can work with.