### PR TITLE
Implemented `else if`, closes #27

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -245,11 +245,19 @@ func (me *MethodExpression) String() string {
 	return out.String()
 }
 
-type IfExpression struct {
-	Token       token.Token // The 'if' token
+// A scenario is used to
+// represent a path within an
+// IF block (if x = 2 { return x}).
+// It has a condition (x = 2)
+// and a consenquence (return x).
+type Scenario struct {
 	Condition   Expression
 	Consequence *BlockStatement
-	Alternative *BlockStatement
+}
+
+type IfExpression struct {
+	Token     token.Token // The 'if' token
+	Scenarios []*Scenario
 }
 
 func (ie *IfExpression) expressionNode()      {}
@@ -257,14 +265,16 @@ func (ie *IfExpression) TokenLiteral() string { return ie.Token.Literal }
 func (ie *IfExpression) String() string {
 	var out bytes.Buffer
 
-	out.WriteString("if")
-	out.WriteString(ie.Condition.String())
-	out.WriteString(" ")
-	out.WriteString(ie.Consequence.String())
+	for i, s := range ie.Scenarios {
+		if i != 0 {
+			out.WriteString("else")
+			out.WriteString(" ")
+		}
 
-	if ie.Alternative != nil {
-		out.WriteString("else ")
-		out.WriteString(ie.Alternative.String())
+		out.WriteString("if")
+		out.WriteString(s.Condition.String())
+		out.WriteString(" ")
+		out.WriteString(s.Consequence.String())
 	}
 
 	return out.String()

--- a/docs/syntax/if.md
+++ b/docs/syntax/if.md
@@ -8,13 +8,15 @@ if x > 0 {
 }
 ```
 
-as well as `else` alternatives:
+as well as `else` and `else if` alternatives:
 
 ``` bash
 if x > 0 {
-    echo("hello world")
+    echo("x is high")
+} else if x < 0 {
+    echo("x is low")
 } else {
-    echo("hello globe")
+    echo("x is actually zero!")
 }
 ```
 
@@ -26,9 +28,6 @@ if (x > 0) {
     echo("hello world")
 }
 ```
-
-Note that `else if` clauses are not supported,
-although they are planned (see [#27](https://github.com/abs-lang/abs/issues/27)).
 
 ## Next
 

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -526,18 +526,19 @@ func evalIfExpression(
 	ie *ast.IfExpression,
 	env *object.Environment,
 ) object.Object {
-	condition := Eval(ie.Condition, env)
-	if isError(condition) {
-		return condition
+	for _, scenario := range ie.Scenarios {
+		condition := Eval(scenario.Condition, env)
+
+		if isError(condition) {
+			return condition
+		}
+
+		if isTruthy(condition) {
+			return Eval(scenario.Consequence, env)
+		}
 	}
 
-	if isTruthy(condition) {
-		return Eval(ie.Consequence, env)
-	} else if ie.Alternative != nil {
-		return Eval(ie.Alternative, env)
-	} else {
-		return NULL
-	}
+	return NULL
 }
 
 func evalWhileExpression(

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -191,6 +191,10 @@ func TestIfElseExpressions(t *testing.T) {
 		{"if 1 > 2 { 10 }", nil},
 		{"if 1 > 2 { 10 } else { 20 }", 20},
 		{"if 1 < 2 { 10 } else { 20 }", 10},
+		{"if 3 > 2 { 1 } else if 1 > 0 {2} else if 5 > 0 {3} else {4}", 1},
+		{"if 1 > 2 { 1 } else if 1 > 0 {2} else if 5 > 0 {3} else {4}", 2},
+		{"if 1 > 2 { 1 } else if 1 > 1 {2} else if 5 > 0 {3} else {4}", 3},
+		{"if 1 > 2 { 1 } else if 1 > 1 {2} else if 5 > 10 {3} else {4}", 4},
 	}
 
 	for _, tt := range tests {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -19,6 +19,8 @@ result = add(five, ten);
 <=>
 if (5 < 10) {
 	return true;
+} else if x {
+	return 0;
 } else {
 	return false;
 }
@@ -141,6 +143,14 @@ $111
 		{token.LBRACE, "{"},
 		{token.RETURN, "return"},
 		{token.TRUE, "true"},
+		{token.SEMICOLON, ";"},
+		{token.RBRACE, "}"},
+		{token.ELSE, "else"},
+		{token.IF, "if"},
+		{token.IDENT, "x"},
+		{token.LBRACE, "{"},
+		{token.RETURN, "return"},
+		{token.NUMBER, "0"},
 		{token.SEMICOLON, ";"},
 		{token.RBRACE, "}"},
 		{token.ELSE, "else"},

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -428,6 +428,222 @@ func TestBooleanExpression(t *testing.T) {
 	}
 }
 
+func TestIfIfElseExpression(t *testing.T) {
+	input := `if x < y { x } else if x > y { y } else if x == y { z }`
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("program.Statements does not contain %d statements. got=%d\n",
+			1, len(program.Statements))
+	}
+
+	stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
+	if !ok {
+		t.Fatalf("program.Statements[0] is not ast.ExpressionStatement. got=%T",
+			program.Statements[0])
+	}
+
+	exp, ok := stmt.Expression.(*ast.IfExpression)
+	if !ok {
+		t.Fatalf("stmt.Expression is not ast.IfExpression. got=%T",
+			stmt.Expression)
+	}
+
+	if len(exp.Scenarios) != 3 {
+		t.Errorf("expression does not have 4 scenarios. got=%d\n",
+			len(exp.Scenarios))
+	}
+
+	// First scenario
+	scenario := exp.Scenarios[0]
+
+	if !testInfixExpression(t, scenario.Condition, "x", "<", "y") {
+		return
+	}
+
+	if len(scenario.Consequence.Statements) != 1 {
+		t.Errorf("consequence is not 1 statements. got=%d\n",
+			len(scenario.Consequence.Statements))
+	}
+
+	consequence, ok := scenario.Consequence.Statements[0].(*ast.ExpressionStatement)
+	if !ok {
+		t.Fatalf("Statements[0] is not ast.ExpressionStatement. got=%T",
+			scenario.Consequence.Statements[0])
+	}
+
+	if !testIdentifier(t, consequence.Expression, "x") {
+		return
+	}
+
+	// Second scenario
+	scenario = exp.Scenarios[1]
+
+	if !testInfixExpression(t, scenario.Condition, "x", ">", "y") {
+		return
+	}
+
+	if len(scenario.Consequence.Statements) != 1 {
+		t.Errorf("consequence is not 1 statements. got=%d\n",
+			len(scenario.Consequence.Statements))
+	}
+
+	consequence, ok = scenario.Consequence.Statements[0].(*ast.ExpressionStatement)
+	if !ok {
+		t.Fatalf("Statements[0] is not ast.ExpressionStatement. got=%T",
+			scenario.Consequence.Statements[0])
+	}
+
+	if !testIdentifier(t, consequence.Expression, "y") {
+		return
+	}
+
+	// Third scenario
+	scenario = exp.Scenarios[2]
+
+	if !testInfixExpression(t, scenario.Condition, "x", "==", "y") {
+		return
+	}
+
+	if len(scenario.Consequence.Statements) != 1 {
+		t.Errorf("consequence is not 1 statements. got=%d\n",
+			len(scenario.Consequence.Statements))
+	}
+
+	consequence, ok = scenario.Consequence.Statements[0].(*ast.ExpressionStatement)
+	if !ok {
+		t.Fatalf("Statements[0] is not ast.ExpressionStatement. got=%T",
+			scenario.Consequence.Statements[0])
+	}
+
+	if !testIdentifier(t, consequence.Expression, "z") {
+		return
+	}
+}
+
+func TestIfIfElseElseExpression(t *testing.T) {
+	input := `if x < y { x } else if x > y { y } else if x == y { z } else { a }`
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("program.Statements does not contain %d statements. got=%d\n",
+			1, len(program.Statements))
+	}
+
+	stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
+	if !ok {
+		t.Fatalf("program.Statements[0] is not ast.ExpressionStatement. got=%T",
+			program.Statements[0])
+	}
+
+	exp, ok := stmt.Expression.(*ast.IfExpression)
+	if !ok {
+		t.Fatalf("stmt.Expression is not ast.IfExpression. got=%T",
+			stmt.Expression)
+	}
+
+	if len(exp.Scenarios) != 4 {
+		t.Errorf("expression does not have 4 scenarios. got=%d\n",
+			len(exp.Scenarios))
+	}
+
+	// First scenario
+	scenario := exp.Scenarios[0]
+
+	if !testInfixExpression(t, scenario.Condition, "x", "<", "y") {
+		return
+	}
+
+	if len(scenario.Consequence.Statements) != 1 {
+		t.Errorf("consequence is not 1 statements. got=%d\n",
+			len(scenario.Consequence.Statements))
+	}
+
+	consequence, ok := scenario.Consequence.Statements[0].(*ast.ExpressionStatement)
+	if !ok {
+		t.Fatalf("Statements[0] is not ast.ExpressionStatement. got=%T",
+			scenario.Consequence.Statements[0])
+	}
+
+	if !testIdentifier(t, consequence.Expression, "x") {
+		return
+	}
+
+	// Second scenario
+	scenario = exp.Scenarios[1]
+
+	if !testInfixExpression(t, scenario.Condition, "x", ">", "y") {
+		return
+	}
+
+	if len(scenario.Consequence.Statements) != 1 {
+		t.Errorf("consequence is not 1 statements. got=%d\n",
+			len(scenario.Consequence.Statements))
+	}
+
+	consequence, ok = scenario.Consequence.Statements[0].(*ast.ExpressionStatement)
+	if !ok {
+		t.Fatalf("Statements[0] is not ast.ExpressionStatement. got=%T",
+			scenario.Consequence.Statements[0])
+	}
+
+	if !testIdentifier(t, consequence.Expression, "y") {
+		return
+	}
+
+	// Third scenario
+	scenario = exp.Scenarios[2]
+
+	if !testInfixExpression(t, scenario.Condition, "x", "==", "y") {
+		return
+	}
+
+	if len(scenario.Consequence.Statements) != 1 {
+		t.Errorf("consequence is not 1 statements. got=%d\n",
+			len(scenario.Consequence.Statements))
+	}
+
+	consequence, ok = scenario.Consequence.Statements[0].(*ast.ExpressionStatement)
+	if !ok {
+		t.Fatalf("Statements[0] is not ast.ExpressionStatement. got=%T",
+			scenario.Consequence.Statements[0])
+	}
+
+	if !testIdentifier(t, consequence.Expression, "z") {
+		return
+	}
+
+	// Fourth scenario, the else
+	scenario = exp.Scenarios[3]
+
+	if !testBooleanLiteral(t, scenario.Condition, true) {
+		return
+	}
+
+	if len(scenario.Consequence.Statements) != 1 {
+		t.Errorf("consequence is not 1 statements. got=%d\n",
+			len(scenario.Consequence.Statements))
+	}
+
+	consequence, ok = scenario.Consequence.Statements[0].(*ast.ExpressionStatement)
+	if !ok {
+		t.Fatalf("Statements[0] is not ast.ExpressionStatement. got=%T",
+			scenario.Consequence.Statements[0])
+	}
+
+	if !testIdentifier(t, consequence.Expression, "a") {
+		return
+	}
+}
+
 func TestIfExpression(t *testing.T) {
 	input := `if x < y { x }`
 
@@ -453,83 +669,30 @@ func TestIfExpression(t *testing.T) {
 			stmt.Expression)
 	}
 
-	if !testInfixExpression(t, exp.Condition, "x", "<", "y") {
+	if len(exp.Scenarios) != 1 {
+		t.Errorf("expression does not have 4 scenarios. got=%d\n",
+			len(exp.Scenarios))
+	}
+
+	// First scenario
+	scenario := exp.Scenarios[0]
+
+	if !testInfixExpression(t, scenario.Condition, "x", "<", "y") {
 		return
 	}
 
-	if len(exp.Consequence.Statements) != 1 {
+	if len(scenario.Consequence.Statements) != 1 {
 		t.Errorf("consequence is not 1 statements. got=%d\n",
-			len(exp.Consequence.Statements))
+			len(scenario.Consequence.Statements))
 	}
 
-	consequence, ok := exp.Consequence.Statements[0].(*ast.ExpressionStatement)
+	consequence, ok := scenario.Consequence.Statements[0].(*ast.ExpressionStatement)
 	if !ok {
 		t.Fatalf("Statements[0] is not ast.ExpressionStatement. got=%T",
-			exp.Consequence.Statements[0])
+			scenario.Consequence.Statements[0])
 	}
 
 	if !testIdentifier(t, consequence.Expression, "x") {
-		return
-	}
-
-	if exp.Alternative != nil {
-		t.Errorf("exp.Alternative.Statements was not nil. got=%+v", exp.Alternative)
-	}
-}
-
-func TestIfElseExpression(t *testing.T) {
-	input := `if x < y { x } else { y }`
-
-	l := lexer.New(input)
-	p := New(l)
-	program := p.ParseProgram()
-	checkParserErrors(t, p)
-
-	if len(program.Statements) != 1 {
-		t.Fatalf("program.Statements does not contain %d statements. got=%d\n",
-			1, len(program.Statements))
-	}
-
-	stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
-	if !ok {
-		t.Fatalf("program.Statements[0] is not ast.ExpressionStatement. got=%T",
-			program.Statements[0])
-	}
-
-	exp, ok := stmt.Expression.(*ast.IfExpression)
-	if !ok {
-		t.Fatalf("stmt.Expression is not ast.IfExpression. got=%T", stmt.Expression)
-	}
-
-	if !testInfixExpression(t, exp.Condition, "x", "<", "y") {
-		return
-	}
-
-	if len(exp.Consequence.Statements) != 1 {
-		t.Errorf("consequence is not 1 statements. got=%d\n",
-			len(exp.Consequence.Statements))
-	}
-
-	consequence, ok := exp.Consequence.Statements[0].(*ast.ExpressionStatement)
-	if !ok {
-		t.Fatalf("Statements[0] is not ast.ExpressionStatement. got=%T",
-			exp.Consequence.Statements[0])
-	}
-
-	if !testIdentifier(t, consequence.Expression, "x") {
-		return
-	}
-
-	if len(exp.Alternative.Statements) != 1 {
-		t.Errorf("exp.Alternative.Statements does not contain 1 statements. got=%d\n", len(exp.Alternative.Statements))
-	}
-
-	alternative, ok := exp.Alternative.Statements[0].(*ast.ExpressionStatement)
-	if !ok {
-		t.Fatalf("Statements[0] is not ast.ExpressionStatement. got=%T", exp.Alternative.Statements[0])
-	}
-
-	if !testIdentifier(t, alternative.Expression, "y") {
 		return
 	}
 }


### PR DESCRIPTION
This commit adds the ability to add multiple IF
conditions in an IF block by using `if else`:

```
if x {
  ...
} else if y {
  ...
} else if z {
  ...
} else {
  ...
}
```

I decided to change the data structure that represents
IFs because it was very limited, only allowing for
a condition, a consequence and an alternative consequence.

Now IFs are a list of `Scenario`, made of conditions and
consequences. If we encounter a bare `else` we set the condition
of that scenario to true, so that it always evaluates to true.

One funny thing that this structure does is that it allows
for code like this:

```
if x {
  ...
} else {
  ...
} else if y {
  ...
}
```

(`else` before `else if`)

I honestly don't mind having this (it's a fun easter egg), but
we might want to raise a parser error later on if users find it
annoying.