### PR TITLE
Added support for backticked commands `` `command` ``, kinda closes #41

### DIFF
--- a/docs/syntax/system-commands.md
+++ b/docs/syntax/system-commands.md
@@ -4,11 +4,11 @@ Executing system commands is one of the most important features
 of ABS, as it allows the mixing of conveniency of the shell with
 the syntax of a modern programming language.
 
-Commands are executed with `$()`, which resembles Bash's
-syntax to execute commands in a subshell:
+Commands are executed either with `$(command)` or `` `command` ``, which resemble Bash's syntax to execute commands in a subshell:
 
 ``` bash
 date = $(date) # "Sun Apr 1 04:30:59 +01 1995"
+date = `date` # "Sun Apr 1 04:30:59 +01 1995"
 ```
 
 As you can see, the return value of a command is a simple
@@ -31,6 +31,12 @@ ls = $(ls -la)
 if ls.ok {
     echo("hello world")
 }
+
+# or
+
+if `ls -la`.ok {
+    echo("hello world")
+}
 ```
 
 You can also replace parts of the command with variables
@@ -50,9 +56,10 @@ $(echo $PWD) # "" since the ABS variable PWD doesn't exist
 $(echo \$PWD) # "/go/src/github.com/abs-lang/abs"
 ```
 
-Currently, commands need to be on their own line, meaning
-that you will not be able to have additional code
-on the same line. This will throw an error:
+Currently, commands that use the `$()` syntax need to be
+on their own line, meaning that you will not
+be able to have additional code on the same line.
+This will throw an error:
 
 ``` bash
 $(sleep 10); echo("hello world")

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -1070,6 +1070,11 @@ func TestCommand(t *testing.T) {
 		{`$(echo -n hello world)`, "hello world"},
 		{`$(echo hello world | xargs echo -n)`, "hello world"},
 		{`$(echo \$CONTEXT)`, "abs"},
+		{"a = 'A'; b = 'B'; eee = '-e'; `echo $eee -n $a$a$b$b$c$c`", "AABB"},
+		{"`echo -n '123'`", "123"},
+		{"`echo -n hello world`", "hello world"},
+		{"`echo hello world | xargs echo -n`", "hello world"},
+		{"`echo \\$CONTEXT`", "abs"},
 	}
 
 	for _, tt := range tests {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -253,6 +253,10 @@ func (l *Lexer) NextToken() token.Token {
 		tok.Type = token.STRING
 		tok.Position = l.position
 		tok.Literal = l.readString('\'')
+	case '`':
+		tok.Type = token.COMMAND
+		tok.Position = l.position
+		tok.Literal = l.readString('`')
 	case '$':
 		if l.peekChar() == '(' {
 			tok.Type = token.COMMAND

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -39,6 +39,7 @@ for x = 0; x < 10; x = x + 1 {
 "foo bar"
 [1, 2];
 $(echo "()");
+` + "`echo '()'`" + `;
 {"foo": "bar"}
 $(curl icanhazip.com -X POST)
 $(ls *.go);
@@ -212,6 +213,8 @@ $111
 		{token.RBRACKET, "]"},
 		{token.SEMICOLON, ";"},
 		{token.COMMAND, `echo "()"`},
+		{token.SEMICOLON, ";"},
+		{token.COMMAND, `echo '()'`},
 		{token.SEMICOLON, ";"},
 		{token.LBRACE, "{"},
 		{token.STRING, "foo"},

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -987,6 +987,34 @@ func TestCommandParsing(t *testing.T) {
 	testCommand(t, command, "curl icanhazip.com -X POST")
 }
 
+func TestBacktickParsing(t *testing.T) {
+	input := "`curl icanhazip.com -X POST`"
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("program.Statements does not contain %d statements. got=%d\n",
+			1, len(program.Statements))
+	}
+
+	stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
+	if !ok {
+		t.Fatalf("program.Statements[0] is not ast.ExpressionStatement. got=%T",
+			program.Statements[0])
+	}
+
+	command, ok := stmt.Expression.(*ast.CommandExpression)
+	if !ok {
+		t.Fatalf("stmt.Expression is not ast.CommandExpression. got=%T",
+			stmt.Expression)
+	}
+
+	testCommand(t, command, "curl icanhazip.com -X POST")
+}
+
 func TestFunctionParameterParsing(t *testing.T) {
 	tests := []struct {
 		input          string


### PR DESCRIPTION
For now we can probably live with the original syntax (`$()`)
having to be on its own line.