### PR TITLE
Allow, destructuring hashes, closes #47

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -487,7 +487,9 @@ func TestAssignStatements(t *testing.T) {
 		{"a = 5; b = a; b;", 5},
 		{"a = 5; b = a; c = a + b + 5; c;", 15},
 		{"a, b, c = [1]; a;", 1},
+		{`a, b, c = {"a": 1}; a;`, 1},
 		{"a, b, c = [1]; b;", nil},
+		{`a, b, c = {"a": 1}; b;`, nil},
 		{`a = 10 + 1 + 2
 b, c = [1, 2]; b`, 1},
 		{`a = 10 + 1 + 2

--- a/object/object.go
+++ b/object/object.go
@@ -236,6 +236,12 @@ type Hash struct {
 }
 
 func (h *Hash) Type() ObjectType { return HASH_OBJ }
+func (h *Hash) GetPair(key string) (HashPair, bool) {
+	record, ok := h.Pairs[HashKey{Type: "STRING", Value: key}]
+
+	return record, ok
+}
+
 func (h *Hash) Inspect() string {
 	var out bytes.Buffer
 


### PR DESCRIPTION
```
myhash = {"some": "thing", "over": "the rainbow", "x": "y"}
some, over = myhash
echo(some) # "thing"
```

@ntwrick I had to revert one of your changes we introduced
when adding error lines etc. When we evaluate null literals
we always return a new object, and this means that when
you compare `null == null` that is `false` as they're 2
different objects. For now I reverted that line you changed
but maybe we could also think of adding a special case to
handle `==` with nulls. Problem is, you'd have to add another
special case for `!=` so I think it's probably easier to just
reuse the same object for nulls...what do you think?