### PR TITLE
Allow to iterate over hashes, closes #139

### DIFF
--- a/docs/syntax/for.md
+++ b/docs/syntax/for.md
@@ -56,10 +56,14 @@ echo(y) # 9
 ## In form
 
 The "in" form of the `for` loops allows you to iterate over
-an array:
+an array or an hash:
 
 ``` bash
 for x in [1, 2, 3] {
+    # x is 1, 2, 3
+}
+
+for x in {"a": 1, "b": 2, "c": 3} {
     # x is 1, 2, 3
 }
 ```
@@ -71,6 +75,11 @@ for k, v in [1, 2, 3] {
     # k is 0, 1, 2
     # v is 1, 2, 3
 }
+
+for k, v in {"a": 1, "b": 2, "c": 3} {
+    # k is a, b, c
+    # v is 1, 2, 3
+}
 ```
 
 In terms of scoping, the "in" form follows the same rules
@@ -79,13 +88,13 @@ as the standard one, meaning that:
 ``` bash
 k = "hello world"
 
-for v in [1, 2, 3] {
+for k, v in [1, 2, 3] {
     # k is 0, 1, 2
     # v is 1, 2, 3
 }
 
-echo(v) # "hello world"
-echo(k) # v is not defined
+echo(k) # "hello world"
+echo(v) # v is not defined
 ```
 
 ## Next

--- a/docs/types/hash.md
+++ b/docs/types/hash.md
@@ -12,7 +12,10 @@ Note that the `hash.key` hash property form is the preferred one, as it's more c
 
 Accessing a key that does not exist returns null.
 
-An individual hash element may be assigned to via its `hash["key"]` index or its property `hash.key`. This includes compound operators such as `+=`. Note that a new key may be created as well using `hash["newkey"]` or `hash.newkey`.
+An individual hash element may be assigned to via its `hash["key"]`
+index or its property `hash.key`. This includes compound operators 
+such as `+=`. Note that a new key may be created as well using `hash["newkey"]` or `hash.newkey`:
+
 ```bash
 h = {"a": 1, "b": 2, "c": 3}
 h # {a: 1, b: 2, c: 3}
@@ -37,7 +40,9 @@ h.y = 20
 h # {a: 88, b: 2, c: 3, x: 10, y: 20}
 ```
 
-It is also possible to extend a hash using the `+=` operator with another hash. Note that any existing keys on the left side will be replaced with the same key from the right side.
+It is also possible to extend a hash using the `+=` operator
+with another hash. Note that any existing keys on the left side 
+will be replaced with the same key from the right side:
 
 ```bash
 h = {"a": 1, "b": 2, "c": 3}
@@ -48,7 +53,9 @@ h += {"c": 33, "d": 4, "e": 5}
 h   # {a: 1, b: 2, c: 33, d: 4, e: 5}
 ```
 
-In a similar way, we can make a **shallow** copy of a hash using the `+` operator with an empty hash. Be careful, the empty hash must be on the left side of the `+` operator.
+In a similar way, we can make a **shallow** copy of a hash using
+the `+` operator with an empty hash. Be careful, the empty hash 
+must be on the left side of the `+` operator:
 
 ```bash
 a = {"a": 1, "b": 2, "c": 3}
@@ -65,7 +72,10 @@ b   # {a: 99, b: 2, c: 3}
 a   # {a: 1, b: 2, c: 3}
 ```
 
-If the left side is a `hash["key"]` or `hash.key` and the right side is a hash, then the resulting hash will have a new nested hash at `hash.newkey`. This includes `hash["newkey"]` or `hash.newKey` as well.
+If the left side is a `hash["key"]` or `hash.key` and the
+right side is a hash, then the resulting hash will have a
+new nested hash at `hash.newkey`. This includes `hash["newkey"]`
+or `hash.newKey` as well:
 
 ```bash
 h = {"a": 1, "b": 2, "c": 3}

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -768,28 +768,28 @@ func evalForInExpression(
 			i.Reset()
 		}()
 
-		return loopIterable(i.Next, env, fie, 0)
+		return loopIterable(i.Next, env, fie)
 	case *object.Builtin:
 		if i.Next == nil {
 			return newError(fie.Token, "builtin function cannot be used in loop")
 		}
 
-		return loopIterable(i.Next, env, fie, 0)
+		return loopIterable(i.Next, env, fie)
 	default:
 		return newError(fie.Token, "'%s' is a %s, not an iterable, cannot be used in for loop", i.Inspect(), i.Type())
 	}
 }
 
-func loopIterable(next func(int) (int, object.Object), env *object.Environment, fie *ast.ForInExpression, pos int) object.Object {
-	k, v := next(pos)
+func loopIterable(next func() (object.Object, object.Object), env *object.Environment, fie *ast.ForInExpression) object.Object {
+	k, v := next()
 
-	if k < 0 || v == EOF {
+	if k == nil || v == EOF {
 		return NULL
 	}
 
 	// set the special k v variables in the
 	// environment
-	env.Set(fie.Key, &object.Number{Token: fie.Token, Value: float64(k)})
+	env.Set(fie.Key, k)
 	env.Set(fie.Value, v)
 	err := Eval(fie.Block, env)
 
@@ -797,8 +797,8 @@ func loopIterable(next func(int) (int, object.Object), env *object.Environment, 
 		return err
 	}
 
-	if k >= 0 {
-		return loopIterable(next, env, fie, pos+1)
+	if k != nil {
+		return loopIterable(next, env, fie)
 	}
 
 	return NULL

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -20,6 +20,7 @@ import (
 
 var scanner *bufio.Scanner
 var tok token.Token
+var scannerPosition int
 
 func init() {
 	scanner = bufio.NewScanner(os.Stdin)
@@ -507,14 +508,17 @@ func stdinFn(args ...object.Object) object.Object {
 
 	return &object.String{Token: tok, Value: scanner.Text()}
 }
-func stdinNextFn(pos int) (int, object.Object) {
+func stdinNextFn() (object.Object, object.Object) {
 	v := scanner.Scan()
 
 	if !v {
-		return pos, EOF
+		return nil, EOF
 	}
 
-	return pos, &object.String{Token: tok, Value: scanner.Text()}
+	defer func() {
+		scannerPosition += 1
+	}()
+	return &object.Number{Value: float64(scannerPosition)}, &object.String{Token: tok, Value: scanner.Text()}
 }
 
 // env(variable:"PWD")


### PR DESCRIPTION
```
for k, v in {"a": 1, "b": 2, "c": 3} {
  echo(k, v)
}
```

This required a bit of refactoring on the iterables,
but nothing too crazy. I like how in this new implementation we check whether we're done iterating when the key is `nil`, rather than when it's `< 0` which is wonky.