### PR TITLE
implement issue #144: cd() only

### DIFF
--- a/docs/types/builtin-function.md
+++ b/docs/types/builtin-function.md
@@ -125,9 +125,8 @@ Note that the path may have a `'~/'` prefix which will be replaced
 with `'homeDir/'`. Also, in Windows, any `'/'` path separator will be
 replaced with `'\'` and path names are not case-sensitive.
 
-Returns the `'/fully/expanded/path'` to the new current working directory and `path.ok`. If `path.ok` is `false`, then the `path`
-is a `null string` and the current working directory is unchanged.
-This supports compound tests such as ``cd() && `ls` ``.
+Returns the `'/fully/expanded/path'` to the new current working directory and `path.ok`.
+If `path.ok` is `false`, that means there was an error changing directory:
 
 ``` bash
 path = cd()
@@ -137,7 +136,7 @@ path        # /home/user or C:\Users\user
 here = pwd()
 path = cd("/path/to/nowhere")
 path.ok         # false
-path            # null string
+path            # 'chdir /path/to/nowhere: no such file or directory'
 here == pwd()   # true
 
 cd("~/git/abs") # /home/user/git/abs or C:\Users\user\git\abs
@@ -148,9 +147,6 @@ cd("/usr/local/bin") # /usr/local/bin
 
 dirs = cd() && `ls`.lines()
 len(dirs)   # number of directories in homeDir
-
-dirs = cd("/path/to/nowhere") && `ls`.lines()
-len(dirs)   # 0
 ```
 
 ### pwd()

--- a/docs/types/builtin-function.md
+++ b/docs/types/builtin-function.md
@@ -116,10 +116,52 @@ type("") # "STRING"
 type({}) # "HASH"
 ```
 
+### cd() or cd(path)
+
+Sets the current working directory to `homeDir` or the given `path`
+in both Linux and Windows.
+
+Note that the path may have a `'~/'` prefix which will be replaced
+with `'homeDir/'`. Also, in Windows, any `'/'` path separator will be
+replaced with `'\'` and path names are not case-sensitive.
+
+Returns the `'/fully/expanded/path'` to the new current working directory and `path.ok`. If `path.ok` is `false`, then the `path`
+is a `null string` and the current working directory is unchanged.
+This supports compound tests such as ``cd() && `ls` ``.
+
+``` bash
+path = cd()
+path.ok     # true
+path        # /home/user or C:\Users\user
+
+here = pwd()
+path = cd("/path/to/nowhere")
+path.ok         # false
+path            # null string
+here == pwd()   # true
+
+cd("~/git/abs") # /home/user/git/abs or C:\Users\user\git\abs
+
+cd("..")        # /home/user/git or C:\Users\user\git
+
+cd("/usr/local/bin") # /usr/local/bin
+
+dirs = cd() && `ls`.lines()
+len(dirs)   # number of directories in homeDir
+
+dirs = cd("/path/to/nowhere") && `ls`.lines()
+len(dirs)   # 0
+```
+
 ### pwd()
 
-Returns the working directory where the script was started for -- equivalent
-to `env("PWD")`:
+Returns the path to the current working directory -- equivalent
+to `env("PWD")`. 
+
+If executed from a script this will initially be the directory
+containing the script.
+
+To change the working directory, see `cd()`.
 
 ``` bash
 pwd() # /go/src/github.com/abs-lang/abs

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -664,6 +664,8 @@ func TestBuiltinFunctions(t *testing.T) {
 		{`arg("o")`, "argument 0 to arg(...) is not supported (got: o, allowed: NUMBER)"},
 		{`arg(3)`, ""},
 		{`pwd().split("").reverse().slice(0, 33).reverse().join("").replace("\\", "/", -1).suffix("/evaluator")`, true}, // Little trick to get travis to run this test, as the base path is not /go/src/
+		{`cwd = cd(); cwd == pwd()`, true},
+		{`cwd = cd("path/to/nowhere"); cwd == pwd()`, false},
 		{`rand(1)`, 0},
 		{`int(10)`, 10},
 		{`int(10.5)`, 10},
@@ -995,7 +997,7 @@ func TestInExpressions(t *testing.T) {
 			errObj, ok := evaluated.(*object.Error)
 
 			if !ok {
-				t.Errorf("no error object returned. got=%T(%+v)", evaluated)
+				t.Errorf("no error object returned. got=%T(%+v)", evaluated, evaluated)
 				continue
 			}
 			logErrorWithPosition(t, errObj.Message, expected)

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -447,7 +447,7 @@ func cdFn(args ...object.Object) object.Object {
 	error := os.Chdir(path)
 	if error != nil {
 		// path does not exist, return null string and !path.ok
-		return &object.String{Token: tok, Value: "", Ok: &object.Boolean{Token: tok, Value: false}}
+		return &object.String{Token: tok, Value: error.Error(), Ok: &object.Boolean{Token: tok, Value: false}}
 	}
 	// return the full path we cd()'d into and path.ok
 	// this will also test true/false for cd("path/to/somewhere") && `ls`


### PR DESCRIPTION
Previous PR straddled the transition from 1.1.x to 1.2.x so the commits were muddy.

Tested cd() function in both linux and win10.
