### PR TITLE
Issue #164: implement abs history

### DIFF
--- a/docs/introduction/how-to-run-abs-code.md
+++ b/docs/introduction/how-to-run-abs-code.md
@@ -19,6 +19,25 @@ Afterwards, you can run ABS scripts with:
 ``` bash
 $ abs path/to/scripts.abs
 ```
+You can also run an executable abs script directly from bash
+ using a bash shebang line at the top of the script file:
+```bash
+$ cat ~/bin/remote.abs
+#! /usr/local/bin/abs
+# remote paths are <target>:<path> 
+from_path = arg(2) 
+to_path = arg(3)
+if ! (from_path && to_path) {
+    if ! from_path {from_path = "<missing>"}
+    if ! to_path {to_path = "<missing>"}
+    echo("FROM: %s, TO: %s", from_path, to_path)
+    exit(1)
+}
+...
+# the executable abs script above is in the PATH at ~/bin/remote.abs
+$ remote.abs
+FROM: <missing>, TO: <missing>
+```
 
 Scripts do not have to have a specific extension,
 although it's recommended to use `.abs` as a
@@ -46,6 +65,49 @@ true
 ERROR: not a function: STRING
 ⧐  ip
 94.204.178.37
+```
+### REPL Command History
+Interactive REPL sessions can now restore and save the command 
+history to a history file containing a maximum number of command lines. 
+
+The prompt live history is restored from the history file when
+the REPL starts and then saved again when the REPL exits. This way you
+can navigate through the command lines from your previous sessions
+by using the up and down arrow keys at the prompt.
+
++ Note well that the live prompt history will show duplicate command
+lines, but the saved history will only contain a single command
+when the previous command and the current command are the same.
+
+The history file name and the maximum number of lines are
+configurable through the OS environment. The default values are
+`ABS_HISTORY_FILE="~/.abs_history"` and `ABS_MAX_HISTORY_LINES=1000`.
+
++ If you wish to suppress the command line history completely, just 
+set `ABS_MAX_HISTORY_LINES=0`. In this case the history file
+will not be created.
+
+For example:
+```bash
+$ export ABS_HISTORY_FILE="~/.abs_hist"
+$ export ABS_MAX_HISTORY_LINES=500
+$ abs
+Hello user, welcome to the ABS (1.1.0) programming language!
+Type 'quit' when you are done, 'help' if you get lost!
+⧐  pwd()
+/home/user/git/abs
+⧐  cd()
+/home/user
+⧐  echo("hello")
+hello
+⧐  quit
+Adios!
+
+$ cat ~/.abs_hist`; echo
+pwd()
+cd()
+echo("hello")
+$
 ```
 
 ## Why is abs interpreted?


### PR DESCRIPTION
 Issue #164: Implemented abs history for interactive REPL. 

History file path and max file size may be configured via OS environment variables otherwise using program defaults. Max file size of zero suppresses history completely.

This has been tested in both linux and win10.