### PR TITLE
Implement issue #164 v2: abs history refactored and cd() util.ExpandPath()

### DIFF
--- a/docs/introduction/how-to-run-abs-code.md
+++ b/docs/introduction/how-to-run-abs-code.md
@@ -19,6 +19,25 @@ Afterwards, you can run ABS scripts with:
 ``` bash
 $ abs path/to/scripts.abs
 ```
+You can also run an executable abs script directly from bash
+ using a bash shebang line at the top of the script file:
+```bash
+$ cat ~/bin/remote.abs
+#! /usr/local/bin/abs
+# remote paths are <target>:<path> 
+from_path = arg(2) 
+to_path = arg(3)
+if ! (from_path && to_path) {
+    if ! from_path {from_path = "<missing>"}
+    if ! to_path {to_path = "<missing>"}
+    echo("FROM: %s, TO: %s", from_path, to_path)
+    exit(1)
+}
+...
+# the executable abs script above is in the PATH at ~/bin/remote.abs
+$ remote.abs
+FROM: <missing>, TO: <missing>
+```
 
 Scripts do not have to have a specific extension,
 although it's recommended to use `.abs` as a
@@ -46,6 +65,49 @@ true
 ERROR: not a function: STRING
 ⧐  ip
 94.204.178.37
+```
+### REPL Command History
+Interactive REPL sessions can now restore and save the command 
+history to a history file containing a maximum number of command lines. 
+
+The prompt live history is restored from the history file when
+the REPL starts and then saved again when the REPL exits. This way you
+can navigate through the command lines from your previous sessions
+by using the up and down arrow keys at the prompt.
+
++ Note well that the live prompt history will show duplicate command
+lines, but the saved history will only contain a single command
+when the previous command and the current command are the same.
+
+The history file name and the maximum number of lines are
+configurable through the OS environment. The default values are
+`ABS_HISTORY_FILE="~/.abs_history"` and `ABS_MAX_HISTORY_LINES=1000`.
+
++ If you wish to suppress the command line history completely, just 
+set `ABS_MAX_HISTORY_LINES=0`. In this case the history file
+will not be created.
+
+For example:
+```bash
+$ export ABS_HISTORY_FILE="~/my_abs_hist"
+$ export ABS_MAX_HISTORY_LINES=500
+$ abs
+Hello user, welcome to the ABS (1.1.0) programming language!
+Type 'quit' when you are done, 'help' if you get lost!
+⧐  pwd()
+/home/user/git/abs
+⧐  cd()
+/home/user
+⧐  echo("hello")
+hello
+⧐  quit
+Adios!
+
+$ cat ~/my_abs_hist`; echo
+pwd()
+cd()
+echo("hello")
+$
 ```
 
 ## Why is abs interpreted?

--- a/docs/introduction/how-to-run-abs-code.md
+++ b/docs/introduction/how-to-run-abs-code.md
@@ -67,7 +67,8 @@ ERROR: not a function: STRING
 94.204.178.37
 ```
 ### REPL Command History
-Interactive REPL sessions can now restore and save the command 
+
+Interactive REPL sessions can restore and save the command 
 history to a history file containing a maximum number of command lines. 
 
 The prompt live history is restored from the history file when

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -435,12 +435,7 @@ func cdFn(tok token.Token, args ...object.Object) object.Object {
 		// arg: rawPath
 		pathStr := args[0].(*object.String)
 		rawPath := pathStr.Value
-		// expand bash-style ~/ path prefix to homeDir (also works in windows)
-		if strings.HasPrefix(rawPath, "~/") {
-			path = strings.Replace(rawPath, "~/", path+"/", 1)
-		} else if len(rawPath) > 0 {
-			path = rawPath
-		}
+		path, _ = util.ExpandPath(rawPath)
 	}
 	// NB. windows os.Chdir(path) will convert any '/' in path to '\', however linux will not
 	error := os.Chdir(path)

--- a/repl/history.go
+++ b/repl/history.go
@@ -1,0 +1,111 @@
+package repl
+
+import (
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/abs-lang/abs/util"
+)
+
+/*
+Support for abs history file in the interactive REPL:
+
+1) The current ABS_HISTORY_FILE is loaded into the prompt.Run() cycle
+   using prompt.OptionHistory(getHistory()). This also loads the local history as well.
+   Default ABS_HISTORY_FILE is "~/.abs_history".
+2) Append each non-null, unique next line passed from prompt to the executor() to the local history.
+   NB. the live prompt history shows duplicate next lines, but they are not saved to the local history.
+3) Save the local history whenever the prompt.Run() loop exits (^D) or the executor() exits (on quit).
+   Write the local history to the ABS_HISTORY_FILE up to ABS_MAX_HISTORY_LINES (default 1000 lines).
+
+Note that ABS_HISTORY_FILE and ABS_MAX_HISTORY_LINES variables may come from the OS environment.
+*/
+
+const (
+	ABS_HISTORY_FILE      = "~/.abs_history"
+	ABS_MAX_HISTORY_LINES = "1000"
+)
+
+// expand full path to ABS_HISTORY_FILE for current user and get ABS_MAX_HISTORY_LINES
+func getHistoryConfiguration() (string, int) {
+	// obtain any OS environment variables
+	// ABS_MAX_HISTORY_LINES
+	maxHistoryLines := os.Getenv("ABS_MAX_HISTORY_LINES")
+	if len(maxHistoryLines) == 0 {
+		maxHistoryLines = ABS_MAX_HISTORY_LINES
+	}
+	maxLines, _ := strconv.Atoi(maxHistoryLines)
+	// ABS_HISTORY_FILE
+	historyFile := os.Getenv("ABS_HISTORY_FILE")
+	if len(historyFile) == 0 {
+		historyFile = ABS_HISTORY_FILE
+	}
+	if maxLines > 0 {
+		// expand the ABS_HISTORY_FILE to the user's HomeDir
+		filePath, err := util.ExpandPath(historyFile)
+		if err != nil {
+			os.Exit(99)
+		}
+		historyFile = filePath
+	} else {
+		historyFile = ""
+	}
+	return historyFile, maxLines
+}
+
+// getHistory - read the history file and split it into the local history[...] slice
+func getHistory(historyFile string, maxLines int) []string {
+	var history []string
+	if maxLines == 0 {
+		// do not open a history file for zero max lines
+		return history
+	}
+	// verify the expanded historyFile exists, if not create it now
+	fd, _ := os.OpenFile(historyFile, os.O_RDONLY|os.O_CREATE, 0666)
+	fd.Close()
+	// read the file and split the lines into history[...]
+	bytes, err := ioutil.ReadFile(historyFile)
+	if err != nil {
+		return history
+	}
+	// fill the local history from the file
+	if len(bytes) > 0 {
+		history = strings.Split(string(bytes), "\n")
+	}
+	return history
+}
+
+// addToHistory - append unique next line to local history[...]
+func addToHistory(history []string, maxLines int, line string) []string {
+	if maxLines == 0 {
+		// do not save history for zero max lines
+		return []string{}
+	}
+	// do not save null lines nor duplicate the previous line in local history
+	// NB. this is not the prompt.history which shows all added lines
+	if len(line) > 0 {
+		if len(history) == 0 {
+			history = append(history, line)
+		} else if line != history[len(history)-1] {
+			history = append(history, line)
+		}
+	}
+	return history
+}
+
+// saveHistory - save the local history containing maxLines to historyFile
+func saveHistory(historyFile string, maxLines int, history []string) {
+	if maxLines == 0 {
+		// do not save a history file for zero max lines
+		return
+	}
+	if len(history) > maxLines {
+		// remove the excess lines from the front of the history slice
+		history = history[len(history)-maxLines:]
+	}
+	// write the augmented local history back out to the file
+	historyStr := strings.Join(history, "\n")
+	ioutil.WriteFile(historyFile, []byte(historyStr), 0664)
+}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -33,8 +33,6 @@ var (
 
 func init() {
 	env = object.NewEnvironment()
-	historyFile, maxLines = getHistoryConfiguration()
-	history = getHistory(historyFile, maxLines)
 }
 
 func completer(d prompt.Document) []prompt.Suggest {
@@ -61,6 +59,10 @@ func changeLivePrefix() (string, bool) {
 }
 
 func Start(in io.Reader, out io.Writer) {
+	// get history file only when interactive REPL is running
+	historyFile, maxLines = getHistoryConfiguration()
+	history = getHistory(historyFile, maxLines)
+
 	p := prompt.New(
 		executor,
 		completer,

--- a/util/util.go
+++ b/util/util.go
@@ -1,6 +1,10 @@
 package util
 
-import "strconv"
+import (
+	"os/user"
+	"path/filepath"
+	"strconv"
+)
 
 // Checks whether the element e is in the
 // list of strings s
@@ -17,4 +21,17 @@ func IsNumber(s string) bool {
 	_, err := strconv.ParseFloat(s, 64)
 
 	return err == nil
+}
+
+// ExpandPath (path) resolves leading "~/" to user's HomeDir
+// returns expanded path, error
+func ExpandPath(path string) (string, error) {
+	if len(path) == 0 || path[0] != '~' {
+		return path, nil
+	}
+	usr, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(usr.HomeDir, path[1:]), nil
 }


### PR DESCRIPTION
1) Refactored abs history from `repl.go` into `repl/history.go` and `util.ExpandPath()`.
2) Also using `util.ExpandPath()` in `cd()`
3) Updated docs
4) Tested in linux and win10

Removing previous PR.
