### PR TITLE
Allowed exponential notation when parsing numbers, closes #173

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -48,6 +48,9 @@ func TestEvalNumberExpression(t *testing.T) {
 		input    string
 		expected float64
 	}{
+		{"1e1", 10},
+		{"1e-1", 0.1},
+		{"1e+1", 10},
 		{"5.5", 5.5},
 		{"1.1 + 2.1", 3.2},
 		{"5.5 + 2.2", 7.7},

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -76,6 +76,11 @@ nullo
 &^>><<
 $111
 '123'
+12+12
+12e10
+12e+10
+12e-10
+12e
 `
 
 	tests := []struct {
@@ -282,6 +287,13 @@ $111
 		{token.BIT_LSHIFT, "<<"},
 		{token.ILLEGAL, "$111"},
 		{token.STRING, "123"},
+		{token.NUMBER, "12"},
+		{token.PLUS, "+"},
+		{token.NUMBER, "12"},
+		{token.NUMBER, "12e10"},
+		{token.NUMBER, "12e+10"},
+		{token.NUMBER, "12e-10"},
+		{token.ILLEGAL, ""},
 		{token.EOF, ""},
 	}
 


### PR DESCRIPTION
```
⧐  1e-10
0.0000000001
⧐  '1e-10'.json()
0.0000000001
```

fixes #173 

@ntwrick do you mind double checking this when you have time? Rushed this in a few minutes so there might be something I've been missing, would :heart: a 2nd opinion :)