### PR TITLE
Make it works with wget 1.20.1

### DIFF
--- a/docs/installer.sh
+++ b/docs/installer.sh
@@ -48,8 +48,7 @@ do
 done < "/dev/stdin"
 
 BIN=abs-${VERSION}-${OS}-${ARCH}
-wget https://github.com/abs-lang/abs/releases/download/${VERSION}/${BIN}
-mv ${BIN} ./abs
+wget https://github.com/abs-lang/abs/releases/download/${VERSION}/${BIN} -O ./abs
 chmod +x ./abs
 
 echo "ABS installation completed!"


### PR DESCRIPTION
I got an error when trying to download `abs` binary with `wget` v1.20.1 like the followings:

```
3b579180-2712-11e9-8772-bd49be747a15?X- 100%[============================================================================>]   3.43M   998KB/s    in 3.5s

2019-02-11 16:03:54 (998 KB/s) - ‘3b579180-2712-11e9-8772-bd49be747a15?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20190211%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190211T070350Z&X-Amz-Expires=300&X-Amz-Signature=9b91dc666081ee7939026ad’ saved [3593720/3593720]

mv: cannot stat 'abs-1.1.0-darwin-amd64': No such file or directory
chmod: cannot access './abs': No such file or directory
```

This fix made it work fine. Additionally code becomes just little more concise.