### PR TITLE
Implement #163: ~/.absrc and source(file)

### DIFF
--- a/docs/introduction/how-to-run-abs-code.md
+++ b/docs/introduction/how-to-run-abs-code.md
@@ -20,7 +20,10 @@ Afterwards, you can run ABS scripts with:
 $ abs path/to/scripts.abs
 ```
 You can also run an executable abs script directly from bash
- using a bash shebang line at the top of the script file:
+using a bash shebang line at the top of the script file. 
+
+In this example the abs executable is linked to `/usr/local/bin/abs`
+and the abs script `~/bin/remote.abs` has its execute permissions set.
 ```bash
 $ cat ~/bin/remote.abs
 #! /usr/local/bin/abs
@@ -80,9 +83,12 @@ by using the up and down arrow keys at the prompt.
 lines, but the saved history will only contain a single command
 when the previous command and the current command are the same.
 
-The history file name and the maximum number of lines are
-configurable through the OS environment. The default values are
-`ABS_HISTORY_FILE="~/.abs_history"` and `ABS_MAX_HISTORY_LINES=1000`.
+The history file name and the maximum number of history lines are
+configurable through 
+1) the ABS environment (set by the ABS init file; see below)
+2) the OS environment
+3) The default values are `ABS_HISTORY_FILE="~/.abs_history"` 
+and `ABS_MAX_HISTORY_LINES=1000`.
 
 + If you wish to suppress the command line history completely, just 
 set `ABS_MAX_HISTORY_LINES=0`. In this case the history file
@@ -111,9 +117,41 @@ echo("hello")
 $
 ```
 
+## ABS Init File
+
+When the ABS interpreter starts running, it will load an optional
+ABS script as its init file. The ABS init file path can be 
+configured via the OS environment variable `ABS_INIT_FILE`. The
+default value is `ABS_INIT_FILE=~/.absrc`.
+
+If the `ABS_INIT_FILE` exists, it will be evaluated before the
+interpreter begins in both interactive REPL or script modes.
+The result of all expressions evaluated in the init file become
+part of the ABS global environment which are available to command
+line expressions or script programs.
+
+Also, note that the `ABS_INTERACTIVE` global environment variable
+is pre-set to `true` or `false` so that the init file can determine
+which mode is running. This is useful if you wish to set the ABS
+history configuration variables in the init file to preset the history
+parameters for the interactive REPL. 
+See [REPL Command History](#REPL_Command_History) above.
+
+For example: 
+```bash
+# ABS init script ~/.absrc 
+# For interactive REPL, override default history filename and size
+if ABS_INTERACTIVE {
+    ABS_HISTORY_FILE = "~/.abs_hist"
+    ABS_MAX_HISTORY_LINES = 500
+}
+```
+
+Also see a `template ABS Init File` at [examples](https://github.com/abs-lang/abs/tree/master/examples/absrc.abs).
+
 ## Why is abs interpreted?
 
-ABS' goal is to be a portable, pragmatic, coincise, simple language:
+ABS' goal is to be a portable, pragmatic, concise, simple language:
 great performance comes second.
 
 With this in mind, we made a deliberate choice to avoid

--- a/docs/introduction/how-to-run-abs-code.md
+++ b/docs/introduction/how-to-run-abs-code.md
@@ -132,35 +132,49 @@ line expressions or script programs.
 
 Also, note that the `ABS_INTERACTIVE` global environment variable
 is pre-set to `true` or `false` so that the init file can determine
-which mode is running. This is useful if you wish to set the ABS
-prompt or history configuration variables in the init file. This
-will preset the prompt and history parameters for the interactive REPL. 
-See [REPL Command History](#REPL_Command_History) above.
+which mode is running. This is useful if you wish to set the ABS REPL
+command line prompt or history configuration variables in the init file.
+This will preset the prompt and history parameters for the interactive
+REPL. See [REPL Command History](#REPL_Command_History) above.
 
-The REPL prompt may be configured using `ABS_PROMPT_LIVE_PREFIX` and
-`ABS_PROMPT_PREFIX` from these ABS or OS environment variables. 
-The live prompt follows the current working directory set by `cd()`
-when it is enabled. The prompt prefix replaces the default prefix
-which follows the live current working directory if it is enabled.
+### Configuring the ABS REPL Command Line Prompt
+The ABS REPL command line prompt may be configured at start up using
+`ABS_PROMPT_LIVE_PREFIX` and `ABS_PROMPT_PREFIX` variables from either
+the ABS or OS environments. The default values are
+`ABS_PROMPT_LIVE_PREFIX=false` and `ABS_PROMPT_PREFIX="⧐  "`.
 
-For example, you can create a bash-style prompt: 
+REPL `live prompt` mode follows the current working directory 
+set by `cd()` when `ABS_PROMPT_LIVE_PREFIX=true` and the
+`ABS_PROMPT_PREFIX` variable contains a `template string`.
+A `template string` may contain the following named placeholders:
+* `{user}`: the current userId
+* `{host}`: the local hostname
+* `{dir}`:  the current working directory following `cd()`
+
+REPL `static prompt` mode will be configured if `ABS_PROMPT_PREFIX`
+contains no `template string` or if `ABS_PROMPT_LIVE_PREFIX = false`.
+The `static prompt` will be the value of the `ABS_PROMPT_PREFIX` string
+(if present) or the default prompt `"⧐  "`. Static prompt mode is
+the default for the REPL.
+
+For example, you can create a `bash`-style live prompt: 
 ```bash
 $ cat ~/.absrc
 # ABS init script ~/.absrc 
 # For interactive REPL, override default prompt, history filename and size
 if ABS_INTERACTIVE {
     ABS_PROMPT_LIVE_PREFIX = true
-    ABS_PROMPT_PREFIX = "$ "
+    ABS_PROMPT_PREFIX = "{user}@{host}:{dir}$ "
     ABS_HISTORY_FILE = "~/.abs_hist"
     ABS_MAX_HISTORY_LINES = 500
 }
 $ abs
 Hello user, welcome to the ABS (1.1.0) programming language!
 Type 'quit' when you are done, 'help' if you get lost!
-/home/user/git/abs$ cwd = cd()
-/home/user$ `ls .absrc`
+user@hostname:~/git/abs$ cwd = cd()
+user@hostname:~$ `ls .absrc`
 .absrc
-/home/user$ 
+user@hostname:~$  
 ```
 
 Also see a `template ABS Init File` at [examples](https://github.com/abs-lang/abs/tree/master/examples/absrc.abs).

--- a/docs/introduction/how-to-run-abs-code.md
+++ b/docs/introduction/how-to-run-abs-code.md
@@ -137,15 +137,30 @@ prompt or history configuration variables in the init file. This
 will preset the prompt and history parameters for the interactive REPL. 
 See [REPL Command History](#REPL_Command_History) above.
 
-For example: 
+The REPL prompt may be configured using `ABS_PROMPT_LIVE_PREFIX` and
+`ABS_PROMPT_PREFIX` from these ABS or OS environment variables. 
+The live prompt follows the current working directory set by `cd()`
+when it is enabled. The prompt prefix replaces the default prefix
+which follows the live current working directory if it is enabled.
+
+For example, you can create a bash-style prompt: 
 ```bash
+$ cat ~/.absrc
 # ABS init script ~/.absrc 
 # For interactive REPL, override default prompt, history filename and size
 if ABS_INTERACTIVE {
-    ABS_PROMPT_PREFIX = pwd() + ": "
+    ABS_PROMPT_LIVE_PREFIX = true
+    ABS_PROMPT_PREFIX = "$ "
     ABS_HISTORY_FILE = "~/.abs_hist"
     ABS_MAX_HISTORY_LINES = 500
 }
+$ abs
+Hello user, welcome to the ABS (1.1.0) programming language!
+Type 'quit' when you are done, 'help' if you get lost!
+/home/user/git/abs$ cwd = cd()
+/home/user$ `ls .absrc`
+.absrc
+/home/user$ 
 ```
 
 Also see a `template ABS Init File` at [examples](https://github.com/abs-lang/abs/tree/master/examples/absrc.abs).

--- a/docs/introduction/how-to-run-abs-code.md
+++ b/docs/introduction/how-to-run-abs-code.md
@@ -133,15 +133,16 @@ line expressions or script programs.
 Also, note that the `ABS_INTERACTIVE` global environment variable
 is pre-set to `true` or `false` so that the init file can determine
 which mode is running. This is useful if you wish to set the ABS
-history configuration variables in the init file to preset the history
-parameters for the interactive REPL. 
+prompt or history configuration variables in the init file. This
+will preset the prompt and history parameters for the interactive REPL. 
 See [REPL Command History](#REPL_Command_History) above.
 
 For example: 
 ```bash
 # ABS init script ~/.absrc 
-# For interactive REPL, override default history filename and size
+# For interactive REPL, override default prompt, history filename and size
 if ABS_INTERACTIVE {
+    ABS_PROMPT_PREFIX = pwd() + ": "
     ABS_HISTORY_FILE = "~/.abs_hist"
     ABS_MAX_HISTORY_LINES = 500
 }

--- a/docs/types/builtin-function.md
+++ b/docs/types/builtin-function.md
@@ -212,6 +212,60 @@ Halts the process for as many `ms` you specified:
 sleep(1000) # sleeps for 1 second
 ```
 
+### source(fileName) -- aka src(), include(), import(), or require() 
+
+Evaluates the ABS script `fileName` in the context of the ABS global
+environment. The results of any expressions in the file become
+available to other commands in the REPL command line or to other
+scripts in the current script execution chain. 
+
+This is most useful for creating `library functions` in a script
+that can be used by many other scripts. Often the library functions
+are loaded via the ABS Init File `~/.absrc`. See [ABS Init File](/introduction/how-to-run-abs-code).
+
+For example:
+```bash
+$ cat ~/abs/lib/library.abs
+# Useful function library ~/abs/lib/library.abs
+adder = f(n, i) { n + i }
+
+$ cat ~/.absrc
+# ABS init file ~/.absrc
+source("~/abs/lib/library.abs")
+
+$ abs
+Hello user, welcome to the ABS (1.1.0) programming language!
+Type 'quit' when you are done, 'help' if you get lost!
+⧐ adder(1, 2)
+3
+⧐
+```
+
+In addition to source file inclusion in scripts, you can also use
+`source()` in the interactive REPL to load a script being
+debugged. When the loaded script completes, the REPL command line
+will have access to all variables and functions evaluated in the
+script.
+
+For example:
+```bash
+⧐  source("~/git/abs/tests/test-strings.abs")
+...
+=====================
+>>> Testing split and join strings with expanded LFs:
+s = split("a\nb\nc", "\n")
+echo(s)
+[a, b, c]
+...
+⧐  s
+[a, b, c]
+⧐ 
+```
+
+Note well that `source file recursion` is limited for safety to a
+`depth of 5 levels` to prevent infinite recursion. This is usually
+due to a bug in the script.
+
 ## Next
 
 That's about it for this section!

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -25,6 +25,9 @@ var (
 	Fns   map[string]*object.Builtin
 )
 
+// This program's global environment can be used by builtin's to modify the env
+var globalEnv *object.Environment
+
 // This program's lexer used for error location in Eval(program)
 var lex *lexer.Lexer
 
@@ -43,6 +46,8 @@ func newError(tok token.Token, format string, a ...interface{}) *object.Error {
 // REPL and testing modules call this function to init the global lexer pointer for error location
 // NB. Eval(node, env) is recursive
 func BeginEval(program ast.Node, env *object.Environment, lexer *lexer.Lexer) object.Object {
+	// global environment
+	globalEnv = env
 	// global lexer
 	lex = lexer
 	// run the evaluator

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -446,12 +446,7 @@ func cdFn(tok token.Token, args ...object.Object) object.Object {
 		// arg: rawPath
 		pathStr := args[0].(*object.String)
 		rawPath := pathStr.Value
-		// expand bash-style ~/ path prefix to homeDir (also works in windows)
-		if strings.HasPrefix(rawPath, "~/") {
-			path = strings.Replace(rawPath, "~/", path+"/", 1)
-		} else if len(rawPath) > 0 {
-			path = rawPath
-		}
+		path, _ = util.ExpandPath(rawPath)
 	}
 	// NB. windows os.Chdir(path) will convert any '/' in path to '\', however linux will not
 	error := os.Chdir(path)
@@ -1352,7 +1347,7 @@ func sourceFn(tok token.Token, args ...object.Object) object.Object {
 		return err
 	}
 	// load the source file
-	fileName := args[0].Inspect()
+	fileName, _ := util.ExpandPath(args[0].Inspect())
 	code, error := ioutil.ReadFile(fileName)
 	if error != nil {
 		// source file path does not exist

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -470,10 +470,15 @@ func cdFn(tok token.Token, args ...object.Object) object.Object {
 		// path does not exist, return error string and !path.ok
 		return &object.String{Token: tok, Value: error.Error(), Ok: &object.Boolean{Token: tok, Value: false}}
 	}
-	// return the full path we cd()'d into and path.ok
-	// this will also test true/false for cd("path/to/somewhere") && `ls`
-	dir, _ := os.Getwd()
-	return &object.String{Token: tok, Value: dir, Ok: &object.Boolean{Token: tok, Value: true}}
+	// do not return cwd if live prompt is active
+	livePrompt := util.GetEnvVar(globalEnv, "ABS_PROMPT_LIVE_PREFIX", "false")
+	if livePrompt == "false" {
+		// return the full path we cd()'d into and path.ok
+		// this will also test true/false for cd("path/to/somewhere") && `ls`
+		dir, _ := os.Getwd()
+		return &object.String{Token: tok, Value: dir, Ok: &object.Boolean{Token: tok, Value: true}}
+	}
+	return NULL
 }
 
 // echo(arg:"hello")

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -284,12 +284,28 @@ func getFns() map[string]*object.Builtin {
 			Fn:    sleepFn,
 		},
 		// source("fileName")
+		// aka src(), include(), import(), require()
 		"source": &object.Builtin{
 			Types: []string{object.STRING_OBJ},
 			Fn:    sourceFn,
 		},
-		// src("fileName") -- short form for source()
+		// src("fileName") -- alias for source()
 		"src": &object.Builtin{
+			Types: []string{object.STRING_OBJ},
+			Fn:    sourceFn,
+		},
+		// include("fileName") -- alias for source()
+		"include": &object.Builtin{
+			Types: []string{object.STRING_OBJ},
+			Fn:    sourceFn,
+		},
+		// import("fileName") -- alias for source()
+		"import": &object.Builtin{
+			Types: []string{object.STRING_OBJ},
+			Fn:    sourceFn,
+		},
+		// require("fileName") -- alias for source()
+		"require": &object.Builtin{
 			Types: []string{object.STRING_OBJ},
 			Fn:    sourceFn,
 		},
@@ -1332,6 +1348,7 @@ func sleepFn(tok token.Token, args ...object.Object) object.Object {
 }
 
 // source("fileName")
+// aka src(), include(), import(), require()
 var sourceMaxRecursionDepth = 5
 
 func sourceFn(tok token.Token, args ...object.Object) object.Object {

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -470,15 +470,10 @@ func cdFn(tok token.Token, args ...object.Object) object.Object {
 		// path does not exist, return error string and !path.ok
 		return &object.String{Token: tok, Value: error.Error(), Ok: &object.Boolean{Token: tok, Value: false}}
 	}
-	// do not return cwd if live prompt is active
-	livePrompt := util.GetEnvVar(globalEnv, "ABS_PROMPT_LIVE_PREFIX", "false")
-	if livePrompt == "false" {
-		// return the full path we cd()'d into and path.ok
-		// this will also test true/false for cd("path/to/somewhere") && `ls`
-		dir, _ := os.Getwd()
-		return &object.String{Token: tok, Value: dir, Ok: &object.Boolean{Token: tok, Value: true}}
-	}
-	return NULL
+	// return the full path we cd()'d into and path.ok
+	// this will also test true/false for cd("path/to/somewhere") && `ls`
+	dir, _ := os.Getwd()
+	return &object.String{Token: tok, Value: dir, Ok: &object.Boolean{Token: tok, Value: true}}
 }
 
 // echo(arg:"hello")

--- a/examples/absrc.abs
+++ b/examples/absrc.abs
@@ -1,7 +1,8 @@
 # ABS init script ~/.absrc
 
-# For interactive REPL, override default history filename and size
+# For interactive REPL, override default prompt, history filename and size
 # if ABS_INTERACTIVE {
+#     ABS_PROMPT_PREFIX = pwd() + ": "
 #     ABS_HISTORY_FILE = "~/.abs_history"
 #     ABS_MAX_HISTORY_LINES = 1000
 # }

--- a/examples/absrc.abs
+++ b/examples/absrc.abs
@@ -1,0 +1,10 @@
+# ABS init script ~/.absrc
+
+# For interactive REPL, override default history filename and size
+# if ABS_INTERACTIVE {
+#     ABS_HISTORY_FILE = "~/.abs_history"
+#     ABS_MAX_HISTORY_LINES = 1000
+# }
+
+# source your function libraries here
+# source("/path/to/abs/lib/library.abs")

--- a/examples/absrc.abs
+++ b/examples/absrc.abs
@@ -1,11 +1,12 @@
-# ABS init script ~/.absrc
+## ABS init script ~/.absrc
 
-# For interactive REPL, override default prompt, history filename and size
+## For interactive REPL, override default prompt, history filename and size
 # if ABS_INTERACTIVE {
-#     ABS_PROMPT_PREFIX = pwd() + ": "
+#     ABS_PROMPT_LIVE_PREFIX = true
+#     ABS_PROMPT_PREFIX = "$ "
 #     ABS_HISTORY_FILE = "~/.abs_history"
 #     ABS_MAX_HISTORY_LINES = 1000
 # }
 
-# source your function libraries here
+## source your function libraries here
 # source("/path/to/abs/lib/library.abs")

--- a/examples/absrc.abs
+++ b/examples/absrc.abs
@@ -3,7 +3,7 @@
 ## For interactive REPL, override default prompt, history filename and size
 # if ABS_INTERACTIVE {
 #     ABS_PROMPT_LIVE_PREFIX = true
-#     ABS_PROMPT_PREFIX = "$ "
+#     ABS_PROMPT_PREFIX = "{user}@{host}:{dir}$ "
 #     ABS_HISTORY_FILE = "~/.abs_history"
 #     ABS_MAX_HISTORY_LINES = 1000
 # }

--- a/main.go
+++ b/main.go
@@ -2,10 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"os/user"
-	"strings"
 
 	"github.com/abs-lang/abs/repl"
 )
@@ -14,34 +11,11 @@ var VERSION = "1.1.0"
 
 // The ABS interpreter
 func main() {
-	user, err := user.Current()
-	if err != nil {
-		panic(err)
-	}
-
 	args := os.Args
-
 	if len(args) == 2 && args[1] == "--version" {
 		fmt.Println(VERSION)
 		return
 	}
-
-	// if we're called without arguments,
-	// launch the REPL
-	if len(args) == 1 || strings.HasPrefix(args[1], "-") {
-		fmt.Printf("Hello %s, welcome to the ABS (%s) programming language!\n", user.Username, VERSION)
-		fmt.Printf("Type 'quit' when you're done, 'help' if you get lost!\n")
-		repl.Start(os.Stdin, os.Stdout)
-		return
-	}
-
-	// let's parse our argument as a file
-	code, err := ioutil.ReadFile(args[1])
-
-	if err != nil {
-		fmt.Println(err.Error())
-		os.Exit(1)
-	}
-
-	repl.Run(string(code), false)
+	// begin the REPL
+	repl.BeginRepl(args, VERSION)
 }

--- a/repl/history.go
+++ b/repl/history.go
@@ -36,34 +36,14 @@ const (
 func getHistoryConfiguration() (string, int) {
 	// obtain any ABS global environment vars or OS environment vars
 	// ABS_MAX_HISTORY_LINES
-	var ok bool
-	var maxHistoryLines string
-	maxHistoryLinesObj, ok := env.Get("ABS_MAX_HISTORY_LINES")
-	if ok {
-		maxHistoryLines = maxHistoryLinesObj.Inspect()
-	} else {
-		maxHistoryLines = os.Getenv("ABS_MAX_HISTORY_LINES")
-		if len(maxHistoryLines) == 0 {
-			maxHistoryLines = ABS_MAX_HISTORY_LINES
-		}
-	}
+	maxHistoryLines := util.GetEnvVar(env, "ABS_MAX_HISTORY_LINES", ABS_MAX_HISTORY_LINES)
 	maxLines, err := strconv.Atoi(maxHistoryLines)
 	if err != nil {
 		maxLines, _ = strconv.Atoi(ABS_MAX_HISTORY_LINES)
 		fmt.Printf("ABS_MAX_HISTORY_LINES must be an integer: %s; using default: %d\n", maxHistoryLines, maxLines)
 	}
 	// ABS_HISTORY_FILE
-	var historyFile string
-	ok = false
-	historyFileObj, ok := env.Get("ABS_HISTORY_FILE")
-	if ok {
-		historyFile = historyFileObj.Inspect()
-	} else {
-		historyFile = os.Getenv("ABS_HISTORY_FILE")
-		if len(historyFile) == 0 {
-			historyFile = ABS_HISTORY_FILE
-		}
-	}
+	historyFile := util.GetEnvVar(env, "ABS_HISTORY_FILE", ABS_HISTORY_FILE)
 	if maxLines > 0 {
 		// expand the ABS_HISTORY_FILE to the user's HomeDir
 		filePath, err := util.ExpandPath(historyFile)

--- a/repl/history.go
+++ b/repl/history.go
@@ -29,23 +29,39 @@ const (
 	ABS_MAX_HISTORY_LINES = "1000"
 )
 
-// expand full path to ABS_HISTORY_FILE for current user and get ABS_MAX_HISTORY_LINES
+// Expand full path to ABS_HISTORY_FILE for current user and get ABS_MAX_HISTORY_LINES
+// 1) we look in the ABS global environment as these vars can be set by the ABS init file
+// 2) we look in the OS environment
+// 3) we use the constant defaults
 func getHistoryConfiguration() (string, int) {
-	// obtain any OS environment variables
+	// obtain any ABS global environment vars or OS environment vars
 	// ABS_MAX_HISTORY_LINES
-	maxHistoryLines := os.Getenv("ABS_MAX_HISTORY_LINES")
-	if len(maxHistoryLines) == 0 {
-		maxHistoryLines = ABS_MAX_HISTORY_LINES
+	var ok bool
+	var maxHistoryLines string
+	maxHistoryLinesObj, ok := env.Get("ABS_MAX_HISTORY_LINES")
+	if ok {
+		maxHistoryLines = maxHistoryLinesObj.Inspect()
+	} else {
+		maxHistoryLines = os.Getenv("ABS_MAX_HISTORY_LINES")
+		if len(maxHistoryLines) == 0 {
+			maxHistoryLines = ABS_MAX_HISTORY_LINES
+		}
 	}
-	maxLines, ok := strconv.Atoi(maxHistoryLines)
-	if ok != nil {
+	maxLines, err := strconv.Atoi(maxHistoryLines)
+	if err != nil {
 		maxLines, _ = strconv.Atoi(ABS_MAX_HISTORY_LINES)
 		fmt.Printf("ABS_MAX_HISTORY_LINES must be an integer: %s; using default: %d\n", maxHistoryLines, maxLines)
 	}
 	// ABS_HISTORY_FILE
-	historyFile := os.Getenv("ABS_HISTORY_FILE")
-	if len(historyFile) == 0 {
-		historyFile = ABS_HISTORY_FILE
+	var historyFile string
+	historyFileObj, ok := env.Get("ABS_HISTORY_FILE")
+	if ok {
+		historyFile = historyFileObj.Inspect()
+	} else {
+		historyFile := os.Getenv("ABS_HISTORY_FILE")
+		if len(historyFile) == 0 {
+			historyFile = ABS_HISTORY_FILE
+		}
 	}
 	if maxLines > 0 {
 		// expand the ABS_HISTORY_FILE to the user's HomeDir

--- a/repl/history.go
+++ b/repl/history.go
@@ -54,11 +54,12 @@ func getHistoryConfiguration() (string, int) {
 	}
 	// ABS_HISTORY_FILE
 	var historyFile string
+	ok = false
 	historyFileObj, ok := env.Get("ABS_HISTORY_FILE")
 	if ok {
 		historyFile = historyFileObj.Inspect()
 	} else {
-		historyFile := os.Getenv("ABS_HISTORY_FILE")
+		historyFile = os.Getenv("ABS_HISTORY_FILE")
 		if len(historyFile) == 0 {
 			historyFile = ABS_HISTORY_FILE
 		}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -62,20 +62,43 @@ func changeLivePrefix() (string, bool) {
 	return LivePrefixState.LivePrefix, LivePrefixState.IsEnable
 }
 
+// support for user config of ABS REPL prompt string
+const ABS_PROMPT_PREFIX = "⧐  "
+
+func getAbsPromptPrefix() string {
+	// ABS_PROMPT_PREFIX
+	var promptPrefix string
+	var ok bool
+	promptPrefixObj, ok := env.Get("ABS_PROMPT_PREFIX")
+	if ok {
+		promptPrefix = promptPrefixObj.Inspect()
+	} else {
+		promptPrefix = os.Getenv("ABS_PROMPT_PREFIX")
+		if len(promptPrefix) == 0 {
+			promptPrefix = ABS_PROMPT_PREFIX
+		}
+	}
+	return promptPrefix
+}
+
 func Start(in io.Reader, out io.Writer) {
 	// get history file only when interactive REPL is running
 	historyFile, maxLines = getHistoryConfiguration()
 	history = getHistory(historyFile, maxLines)
+	// get prompt prefix
+	promptPrefix := getAbsPromptPrefix()
+
 	// create and start the command prompt run loop
 	p := prompt.New(
 		executor,
 		completer,
-		prompt.OptionPrefix("⧐  "),
+		prompt.OptionPrefix(promptPrefix),
 		prompt.OptionLivePrefix(changeLivePrefix),
 		prompt.OptionTitle("abs-repl"),
 		prompt.OptionHistory(history),
 	)
 	p.Run()
+
 	// we get here on ^D from the prompt
 	saveHistory(historyFile, maxLines, history)
 }

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -67,18 +67,7 @@ const ABS_PROMPT_PREFIX = "⧐  "
 
 func getAbsPromptPrefix() string {
 	// ABS_PROMPT_PREFIX
-	var promptPrefix string
-	var ok bool
-	promptPrefixObj, ok := env.Get("ABS_PROMPT_PREFIX")
-	if ok {
-		promptPrefix = promptPrefixObj.Inspect()
-	} else {
-		promptPrefix = os.Getenv("ABS_PROMPT_PREFIX")
-		if len(promptPrefix) == 0 {
-			promptPrefix = ABS_PROMPT_PREFIX
-		}
-	}
-	return promptPrefix
+	return util.GetEnvVar(env, "ABS_PROMPT_PREFIX", ABS_PROMPT_PREFIX)
 }
 
 func Start(in io.Reader, out io.Writer) {

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -59,23 +59,26 @@ var LivePrefixState struct {
 }
 
 func changeLivePrefix() (string, bool) {
-	return LivePrefixState.LivePrefix, LivePrefixState.IsEnable
+	pwd, _ := os.Getwd()
+	livePrefix := pwd + LivePrefixState.LivePrefix
+	return livePrefix, LivePrefixState.IsEnable
 }
 
 // support for user config of ABS REPL prompt string
 const ABS_PROMPT_PREFIX = "⧐  "
-
-func getAbsPromptPrefix() string {
-	// ABS_PROMPT_PREFIX
-	return util.GetEnvVar(env, "ABS_PROMPT_PREFIX", ABS_PROMPT_PREFIX)
-}
 
 func Start(in io.Reader, out io.Writer) {
 	// get history file only when interactive REPL is running
 	historyFile, maxLines = getHistoryConfiguration()
 	history = getHistory(historyFile, maxLines)
 	// get prompt prefix
-	promptPrefix := getAbsPromptPrefix()
+	promptPrefix := util.GetEnvVar(env, "ABS_PROMPT_PREFIX", ABS_PROMPT_PREFIX)
+	// get live prompt
+	livePrompt := util.GetEnvVar(env, "ABS_PROMPT_LIVE_PREFIX", "false")
+	if livePrompt == "true" {
+		LivePrefixState.LivePrefix = promptPrefix
+		LivePrefixState.IsEnable = true
+	}
 
 	// create and start the command prompt run loop
 	p := prompt.New(

--- a/tests/test-absrc.abs
+++ b/tests/test-absrc.abs
@@ -3,4 +3,5 @@
 if ABS_INTERACTIVE {
     ABS_HISTORY_FILE = "~/.abs_hist"
     ABS_MAX_HISTORY_LINES = 500
+    ABS_PROMPT_PREFIX = pwd() + ": "
 }

--- a/tests/test-absrc.abs
+++ b/tests/test-absrc.abs
@@ -2,7 +2,7 @@
 ## For interactive REPL, set prompt and override default history filename and size
 if ABS_INTERACTIVE {
     ABS_PROMPT_LIVE_PREFIX = true
-    ABS_PROMPT_PREFIX = "$ "
+    ABS_PROMPT_PREFIX = "{user}@{host}:{dir}$ "
     ABS_HISTORY_FILE = "~/.abs_hist"
     ABS_MAX_HISTORY_LINES = 500
 }

--- a/tests/test-absrc.abs
+++ b/tests/test-absrc.abs
@@ -1,0 +1,4 @@
+if ABS_INTERACTIVE {
+    ABS_HISTORY_FILE = "~/.abs_hist"
+    ABS_MAX_HISTORY_LINES = "500"
+}

--- a/tests/test-absrc.abs
+++ b/tests/test-absrc.abs
@@ -1,7 +1,8 @@
-# ABS init script 
-# For interactive REPL, override default history filename and size
+## ABS init script 
+## For interactive REPL, set prompt and override default history filename and size
 if ABS_INTERACTIVE {
-    ABS_PROMPT_PREFIX = pwd() + ": "
+    ABS_PROMPT_LIVE_PREFIX = true
+    ABS_PROMPT_PREFIX = "$ "
     ABS_HISTORY_FILE = "~/.abs_hist"
     ABS_MAX_HISTORY_LINES = 500
 }

--- a/tests/test-absrc.abs
+++ b/tests/test-absrc.abs
@@ -1,3 +1,5 @@
+# ABS init script 
+# for interactive REPL, override default history filename and size
 if ABS_INTERACTIVE {
     ABS_HISTORY_FILE = "~/.abs_hist"
     ABS_MAX_HISTORY_LINES = "500"

--- a/tests/test-absrc.abs
+++ b/tests/test-absrc.abs
@@ -1,7 +1,7 @@
 # ABS init script 
 # For interactive REPL, override default history filename and size
 if ABS_INTERACTIVE {
+    ABS_PROMPT_PREFIX = pwd() + ": "
     ABS_HISTORY_FILE = "~/.abs_hist"
     ABS_MAX_HISTORY_LINES = 500
-    ABS_PROMPT_PREFIX = pwd() + ": "
 }

--- a/tests/test-absrc.abs
+++ b/tests/test-absrc.abs
@@ -1,6 +1,6 @@
 # ABS init script 
-# for interactive REPL, override default history filename and size
+# For interactive REPL, override default history filename and size
 if ABS_INTERACTIVE {
     ABS_HISTORY_FILE = "~/.abs_hist"
-    ABS_MAX_HISTORY_LINES = "500"
+    ABS_MAX_HISTORY_LINES = 500
 }

--- a/tests/test-source-file.abs
+++ b/tests/test-source-file.abs
@@ -1,0 +1,11 @@
+# source some files
+
+source("tests/test-hash-funcs.abs")
+echo("sourced hash h = %v", h)
+
+# src("tests/test-assign-index.abs")
+# echo("sourced hash h = %v", h)
+# echo("sourced array a = %v", a)
+
+# test recursion at max depth = 5
+src("tests/test-source-file.abs")

--- a/util/util.go
+++ b/util/util.go
@@ -1,9 +1,12 @@
 package util
 
 import (
+	"os"
 	"os/user"
 	"path/filepath"
 	"strconv"
+
+	"github.com/abs-lang/abs/object"
 )
 
 // Checks whether the element e is in the
@@ -34,4 +37,21 @@ func ExpandPath(path string) (string, error) {
 		return "", err
 	}
 	return filepath.Join(usr.HomeDir, path[1:]), nil
+}
+
+// GetEnvVar (varName, defaultVal)
+// Return the varName value from the ABS env, or OS env, or default value in that order
+func GetEnvVar(env *object.Environment, varName, defaultVal string) string {
+	var ok bool
+	var value string
+	valueObj, ok := env.Get(varName)
+	if ok {
+		value = valueObj.Inspect()
+	} else {
+		value = os.Getenv(varName)
+		if len(value) == 0 {
+			value = defaultVal
+		}
+	}
+	return value
 }


### PR DESCRIPTION
Implement issue #163.
1) ABS Init File (default `/.absrc`)
2) `source(file)` inclusion with aliases `src()`, `include()`, `import()`, and `requires()` 
2) REPL live prompt template strings using placeholders `{user}`, `{host}`, and `{dir}`
3) REPL preloads builtin Fns names into global env for command completion
 
Tested in linux and win10.