### PR TITLE
Issue 199 exec(command) function

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ repository.
 
 Since we follow [semver](https://semver.org/),
 when a new feature is released we don't backport it but simply
-create a new version branch, such as `1.2.x`. Bugs, instead,
+create a new version branch, such as `1.3.x`. Bugs, instead,
 might be backported from `1.1.0` to, for example, `1.0.x` and we
 will have a new [release](https://github.com/abs-lang/abs/releases),
 say `1.0.1` for the `1.0.x` version branch.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11
+FROM golang:1.12
 
 RUN apt-get update
 RUN apt-get install bash make git curl jq -y
@@ -13,12 +13,5 @@ ENV CONTEXT=abs
 COPY . /go/src/github.com/abs-lang/abs
 WORKDIR /go/src/github.com/abs-lang/abs
 RUN go get -d -v ./...
-
-# This is simply done because Go
-# will build faster. A docker build
-# is probably less frequent than an ABS
-# build, so...
-RUN make build_simple
-RUN ./builds/abs ./scripts/release.abs
 
 CMD bash

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -317,6 +317,7 @@ type ForInExpression struct {
 	Iterable Expression      // An expression that should return an iterable ([1, 2, 3] or x in 1..10)
 	Key      string
 	Value    string
+	Alternative *BlockStatement
 }
 
 func (fie *ForInExpression) expressionNode()      {}
@@ -333,6 +334,11 @@ func (fie *ForInExpression) String() string {
 	out.WriteString(" in ")
 	out.WriteString(fie.Iterable.String())
 	out.WriteString(fie.Block.String())
+
+	if fie.Alternative != nil {
+		out.WriteString("else")
+		out.WriteString(fie.Alternative.String())
+	}
 
 	return out.String()
 }

--- a/docs/installer.sh
+++ b/docs/installer.sh
@@ -24,7 +24,7 @@ MACHINE_TYPE=$(uname -m)
 if [ "${MACHINE_TYPE}" = 'x86_64' ]; then
   ARCH="amd64"
 fi
-VERSION=1.2.0
+VERSION=1.3.0
 
 echo "Trying to detect the details of your architecture."
 echo ""

--- a/docs/syntax/for.md
+++ b/docs/syntax/for.md
@@ -97,6 +97,25 @@ echo(k) # "hello world"
 echo(v) # v is not defined
 ```
 
+## For ... else ...
+
+`For` loops can also have `else` clause which executes if 
+the list in the `for` condition is empty.
+
+For example, when we run a database query like the following,
+if the "users" list is empty, we will only execute the statements
+inside the `else` clause.
+
+``` bash
+users = db.query("SELECT students WHERE age > 20")
+
+for user in users {
+  print(user)
+} else {
+  print("We don't have students above the age of 20")
+}
+```
+
 ## Next
 
 That's about it for this section!

--- a/docs/syntax/system-commands.md
+++ b/docs/syntax/system-commands.md
@@ -73,6 +73,16 @@ cmd.wait()
 echo("This will be printed after 10s")
 ```
 
+If you ever want to terminate a running command, you can
+use the `kill` method.
+
+``` bash
+cmd = `sleep 10 &`
+cmd.done # false
+cmd.kill()
+cmd.done # true
+```
+
 ## Interpolation
 
 You can also replace parts of the command with variables

--- a/docs/types/builtin-function.md
+++ b/docs/types/builtin-function.md
@@ -234,7 +234,7 @@ $ cat ~/.absrc
 source("~/abs/lib/library.abs")
 
 $ abs
-Hello user, welcome to the ABS (1.2.0) programming language!
+Hello user, welcome to the ABS (1.3.0) programming language!
 Type 'quit' when you are done, 'help' if you get lost!
 ⧐ adder(1, 2)
 3

--- a/docs/types/builtin-function.md
+++ b/docs/types/builtin-function.md
@@ -278,6 +278,45 @@ This will limit the source inclusion depth to 15 levels for this
 `source()` statement and will also apply to future `source()`
 statements until changed.
 
+### exec(command)
+
+Execute the command string using live Standard IO (stdin, stdout, stderr).
+The `exec()` function call does not return a result string unless it fails.
+
+Note well that in Linux the command string may contain a trailing `&`. 
+In this case the `exec()` function will terminate immediately allowing the
+command to be executed in the background outside of ABS. This means that the
+command must either terminate on its own or be killed using `pkill` or similar.
+This way an ABS script can launch a true daemon process that may never terminate.
+
+For example, an ABS script might also be used to marshall the command line args
+for an interactive program such as the nano editor:
+
+``` bash
+$ cat abs/tests/test-exec.abs
+# marshall the args for the nano editor
+# if the filename is not given in the args, prompt for it
+# if the file is located outside the user's home dir, invoke sudo nano filename
+
+cmd = 'nano'
+filename = arg(2)
+homedir = env("HOME")
+
+while filename == '' {
+    echo("Please enter file name for %s: ", cmd)
+    filename = stdin()
+}
+
+if filename.prefix('~/') || filename.prefix(homedir) {
+    sudo = ''
+} else {
+    sudo = 'sudo'
+}
+
+# execute the command with live stdIO
+exec("$sudo $cmd $filename")
+```
+
 ## Next
 
 That's about it for this section!

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -332,6 +332,39 @@ func TestForInExpressions(t *testing.T) {
 	}
 }
 
+func TestForElseExpressions(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{ "a = 0; b = 1; for v in [] { x = a } else { x = b }; x", 1},
+		{ "a = 100; x = 0; for i in  1..-1 { x = i } else { x = a }; x", 100},
+		{ "v = 100; for k, v in [] { v = 0 } else {}; v", 100},
+		{ "for k, v in [] {} else { x = v }; x", "identifier not found: v"},
+		{ "a = 0; for k, v in [] { x = a } else { x = b }; x", "identifier not found: b"},
+		{ "for k, v in [] { x = 0 } else { x = 100 }; z", "identifier not found: z"},
+		{ "for i in 1..3 { x = i } else { x = 0 }; x", 3},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+
+		switch ev := tt.expected.(type) {
+		case int:
+			testNumberObject(t, evaluated, float64(ev))
+		case bool:
+			testBooleanObject(t, evaluated, ev)
+		default:
+			errObj, ok := evaluated.(*object.Error)
+			if !ok {
+				t.Errorf("no error object returned. got=%T(%+v)", evaluated, evaluated)
+				continue
+			}
+			logErrorWithPosition(t, errObj.Message, ev)
+		}
+	}
+}
+
 func TestWhileExpressions(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -337,13 +337,13 @@ func TestForElseExpressions(t *testing.T) {
 		input    string
 		expected interface{}
 	}{
-		{ "a = 0; b = 1; for v in [] { x = a } else { x = b }; x", 1},
-		{ "a = 100; x = 0; for i in  1..-1 { x = i } else { x = a }; x", 100},
-		{ "v = 100; for k, v in [] { v = 0 } else {}; v", 100},
-		{ "for k, v in [] {} else { x = v }; x", "identifier not found: v"},
-		{ "a = 0; for k, v in [] { x = a } else { x = b }; x", "identifier not found: b"},
-		{ "for k, v in [] { x = 0 } else { x = 100 }; z", "identifier not found: z"},
-		{ "for i in 1..3 { x = i } else { x = 0 }; x", 3},
+		{"a = 0; b = 1; for v in [] { x = a } else { x = b }; x", 1},
+		{"a = 100; x = 0; for i in  1..-1 { x = i } else { x = a }; x", 100},
+		{"v = 100; for k, v in [] { v = 0 } else {}; v", 100},
+		{"for k, v in [] {} else { x = v }; x", "identifier not found: v"},
+		{"a = 0; for k, v in [] { x = a } else { x = b }; x", "identifier not found: b"},
+		{"for k, v in [] { x = 0 } else { x = 100 }; z", "identifier not found: z"},
+		{"for i in 1..3 { x = i } else { x = 0 }; x", 3},
 	}
 
 	for _, tt := range tests {
@@ -1172,7 +1172,14 @@ func TestCommand(t *testing.T) {
 			{"`sleep 0.01 &`", ""},
 			{"`sleep 0.01 &`.done", false},
 			{"`sleep 0.01 &`.ok", false},
-			{"`sleep 0.01 &`.wait().ok", false},
+			{"`sleep 0.01 &`.wait().ok", true},
+			{"`sleep 0.01 && echo 123 &`.wait()", "123"},
+			{"`sleep 0.01 && echo 123 &`.kill()", ""},
+			{"`sleep 0.01 && echo 123 &`.kill().done", true},
+			{"`sleep 0.01 && echo 123 &`.kill().ok", false},
+			{"`echo 123; sleep 10 &`.ok", false},
+			{"`echo 123; sleep 10 &`.kill().done", true},
+			{"`echo 123; sleep 10 &`.kill().ok", false},
 		}
 	}
 	for _, tt := range tests {
@@ -1189,6 +1196,15 @@ func TestCommand(t *testing.T) {
 			}
 			if stringObj.Value != expected {
 				t.Errorf("result is not the right string for '%s'. got='%s', want='%s'", tt.input, stringObj.Value, expected)
+			}
+		case bool:
+			booleanObj, ok := evaluated.(*object.Boolean)
+			if !ok {
+				t.Errorf("object is not Boolean. got=%T (%+v)", evaluated, evaluated)
+				continue
+			}
+			if booleanObj.Value != expected {
+				t.Errorf("result is not the right boolean for '%s'. got='%t', want='%t'", tt.input, booleanObj.Value, expected)
 			}
 		}
 	}

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -325,9 +325,10 @@ func getFns() map[string]*object.Builtin {
 			Types: []string{object.STRING_OBJ},
 			Fn:    sourceFn,
 		},
+		// exec(command) -- execute command with interactive stdIO
 		"exec": &object.Builtin{
 			Types: []string{object.STRING_OBJ},
-			Fn:    runFn,
+			Fn:    execFn,
 		},
 	}
 }
@@ -1553,8 +1554,8 @@ func sourceFn(tok token.Token, args ...object.Object) object.Object {
 	return evaluated
 }
 
-func runFn(tok token.Token, args ...object.Object) object.Object {
-	err := validateArgs(tok, "run", args, 1, [][]string{{object.STRING_OBJ}})
+func execFn(tok token.Token, args ...object.Object) object.Object {
+	err := validateArgs(tok, "exec", args, 1, [][]string{{object.STRING_OBJ}})
 	if err != nil {
 		return err
 	}

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -329,6 +329,10 @@ func getFns() map[string]*object.Builtin {
 			Types: []string{object.STRING_OBJ},
 			Fn:    runFn,
 		},
+		"exec": &object.Builtin{
+			Types: []string{object.STRING_OBJ},
+			Fn:    runFn,
+		},
 	}
 }
 
@@ -1570,9 +1574,9 @@ func runFn(tok token.Token, args ...object.Object) object.Object {
 		commands = []string{"/C", cmd}
 		executor = "cmd.exe"
 	} else { //assume it's linux, darwin, freebsd, openbsd, solaris, etc
-		// invoke bash commands with login and interactive options (-li) --
-		// this allows the use of aliases and commands in $PATH
-		commands = []string{"-lic", cmd}
+		// invoke bash commands with login option (-l) --
+		// this allows the use of commands in $PATH
+		commands = []string{"-lc", cmd}
 		executor = "bash"
 	}
 	// set up command to execute using our stdIO
@@ -1588,7 +1592,7 @@ func runFn(tok token.Token, args ...object.Object) object.Object {
 	runErr := c.Run()
 
 	if runErr != nil {
-		return err
+		return &object.String{Value: runErr.Error()}
 	}
 	return NULL
 }

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -237,6 +237,10 @@ func getFns() map[string]*object.Builtin {
 			Types: []string{object.STRING_OBJ},
 			Fn:    waitFn,
 		},
+		"kill": &object.Builtin{
+			Types: []string{object.STRING_OBJ},
+			Fn:    killFn,
+		},
 		// trim("abc")
 		"trim": &object.Builtin{
 			Types: []string{object.STRING_OBJ},
@@ -1158,6 +1162,27 @@ func waitFn(tok token.Token, args ...object.Object) object.Object {
 	}
 
 	cmd.Wait()
+	return cmd
+}
+
+// kill(`sleep 10 &`)
+func killFn(tok token.Token, args ...object.Object) object.Object {
+	err := validateArgs(tok, "kill", args, 1, [][]string{{object.STRING_OBJ}})
+	if err != nil {
+		return err
+	}
+
+	cmd := args[0].(*object.String)
+
+	if cmd.Cmd == nil {
+		return cmd
+	}
+
+	errCmdKill := cmd.Kill()
+
+	if errCmdKill != nil {
+		return newError(tok, "Error killing command %s with error %s", cmd.Inspect(), errCmdKill.Error())
+	}
 	return cmd
 }
 

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -325,10 +325,6 @@ func getFns() map[string]*object.Builtin {
 			Types: []string{object.STRING_OBJ},
 			Fn:    sourceFn,
 		},
-		"run": &object.Builtin{
-			Types: []string{object.STRING_OBJ},
-			Fn:    runFn,
-		},
 		"exec": &object.Builtin{
 			Types: []string{object.STRING_OBJ},
 			Fn:    runFn,

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/abs-lang/abs/repl"
 )
 
-var VERSION = "1.2.0"
+var VERSION = "1.3.0"
 
 // The ABS interpreter
 func main() {

--- a/object/object.go
+++ b/object/object.go
@@ -216,6 +216,25 @@ func (s *String) Wait() {
 	s.mux.Unlock()
 }
 
+// To be called when we want to
+// kill the background command
+func (s *String) Kill() error {
+	err := s.Cmd.Process.Kill()
+
+	// The command value includes output and possible error
+	// We might want to change this
+	output := s.Stdout.String()
+	outputErr := s.Stderr.String()
+	s.Value = strings.TrimSpace(output) + strings.TrimSpace(outputErr)
+
+	if err != nil {
+		return err
+	}
+
+	s.Done = TRUE
+	return nil
+}
+
 // Sets the result of the underlying command
 // on the string.
 // 3 things are set:

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -677,6 +677,21 @@ func (p *Parser) parseForInExpression(initialExpression *ast.ForExpression) ast.
 
 	expression.Block = p.parseBlockStatement()
 
+	// for x in [] {
+	// 	echo("shouldn't be here")
+	// } else {
+	//  echo("ok")
+	// }
+	if p.peekTokenIs(token.ELSE) {
+		p.nextToken()
+
+		if !p.expectPeek(token.LBRACE) {
+			return nil
+		}
+
+		expression.Alternative = p.parseBlockStatement()
+	}
+
 	return expression
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -912,6 +912,61 @@ func TestForInExpression(t *testing.T) {
 	}
 }
 
+func TestForElseExpression(t *testing.T) {
+	tests := []struct {
+		input string
+	}{
+		{`for x in [] { x } else { y }`},
+		{`for x in {} { x } else { y }`},
+	}
+
+	for _, tt := range tests {
+		l := lexer.New(tt.input)
+		p := New(l)
+		program := p.ParseProgram()
+		checkParserErrors(t, p)
+
+		if len(program.Statements) != 1 {
+			t.Fatalf("program.Statements does not contain %d statements. got=%d\n", 1, len(program.Statements))
+		}
+		stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
+		if !ok {
+			t.Fatalf("program.Statements[0] is not ast.ExpressionStatement. got=%T", program.Statements[0])
+		}
+
+		exp, ok := stmt.Expression.(*ast.ForInExpression)
+		if !ok {
+			t.Fatalf("stmt.Expression is not ast.ForExpression. got=%T", stmt.Expression)
+		}
+
+		if len(exp.Block.Statements) != 1 {
+			t.Errorf("block is not 1 statements. got=%d\n", len(exp.Block.Statements))
+		}
+
+		block, ok := exp.Block.Statements[0].(*ast.ExpressionStatement)
+		if !ok {
+			t.Fatalf("Statements[0] is not ast.ExpressionStatement. got=%T", exp.Block.Statements[0])
+		}
+
+		if !testIdentifier(t, block.Expression, "x") {
+			return
+		}
+
+		if len(exp.Alternative.Statements) != 1 {
+			t.Errorf("Alternative is not 1 statements. got=%d\n", len(exp.Block.Statements))
+		}
+
+		alternative, ok := exp.Alternative.Statements[0].(*ast.ExpressionStatement)
+		if !ok {
+			t.Fatalf("Alternative statements[0] is not ast.ExpressionStatement. got=%T", exp.Block.Statements[0])
+		}
+
+		if !testIdentifier(t, alternative.Expression, "y") {
+			return
+		}
+	}
+}
+
 func TestFunctionLiteralParsing(t *testing.T) {
 	input := `f(x, y) { x + y; }`
 

--- a/tests/test-exec.abs
+++ b/tests/test-exec.abs
@@ -1,0 +1,21 @@
+# marshall the args for the nano editor
+# if the filename is not given in the args, prompt for it
+# if the file is located outside the user's home dir, invoke sudo nano filename
+
+cmd = 'nano'
+filename = arg(2)
+homedir = env("HOME")
+
+while filename == '' {
+    echo("Please enter file name for %s: ", cmd)
+    filename = stdin()
+}
+
+if filename.prefix('~/') || filename.prefix(homedir) {
+    sudo = ''
+} else {
+    sudo = 'sudo'
+}
+
+# execute the command with live stdIO
+exec("$sudo $cmd $filename")


### PR DESCRIPTION
Here is my proposal for an `exec(command)` builtin function to solve issue #199.

Considering that implementing a builtin function does not require new lexical support and that `exec(command)` is similar to what `linux C libs` provide and the `golang exec module` supports, it seems to me that this model is reasonably expressive as well as easy to implement.

See `tests/test-exec.abs` as example of an abs script that marshalls args for a an interactive editor and then executes it with live stdIO. This works in both `linux with nano` and `win10 with notepad`. It also works for commands in linux that terminate with `&` which means we can launch a true daemon process in the background as well.

As a bonus, the `$var` command string interpolation code has been moved to the `util` module where it can be shared by regular commands as well as exec commands.
