### PR TITLE
Issue 199 exec(command) builtin function

### DIFF
--- a/docs/types/builtin-function.md
+++ b/docs/types/builtin-function.md
@@ -278,45 +278,6 @@ This will limit the source inclusion depth to 15 levels for this
 `source()` statement and will also apply to future `source()`
 statements until changed.
 
-### exec(command)
-
-Execute the command string using live Standard IO (stdin, stdout, stderr).
-The `exec()` function call does not return a result string unless it fails.
-
-Note well that in Linux the command string may contain a trailing `&`. 
-In this case the `exec()` function will terminate immediately allowing the
-command to be executed in the background outside of ABS. This means that the
-command must either terminate on its own or be killed using `pkill` or similar.
-This way an ABS script can launch a true daemon process that may never terminate.
-
-For example, an ABS script might also be used to marshall the command line args
-for an interactive program such as the nano editor:
-
-``` bash
-$ cat abs/tests/test-exec.abs
-# marshall the args for the nano editor
-# if the filename is not given in the args, prompt for it
-# if the file is located outside the user's home dir, invoke sudo nano filename
-
-cmd = 'nano'
-filename = arg(2)
-homedir = env("HOME")
-
-while filename == '' {
-    echo("Please enter file name for %s: ", cmd)
-    filename = stdin()
-}
-
-if filename.prefix('~/') || filename.prefix(homedir) {
-    sudo = ''
-} else {
-    sudo = 'sudo'
-}
-
-# execute the command with live stdIO
-exec("$sudo $cmd $filename")
-```
-
 ## Next
 
 That's about it for this section!

--- a/docs/types/builtin-function.md
+++ b/docs/types/builtin-function.md
@@ -278,6 +278,45 @@ This will limit the source inclusion depth to 15 levels for this
 `source()` statement and will also apply to future `source()`
 statements until changed.
 
+### exec(command)
+
+Execute the command string using live Standard IO (stdin, stdout, stderr).
+The `exec()` function call does not return a result string unless it fails.
+
+Note well that in Linux the command string may contain a trailing `&`. 
+In this case the `exec()` function will terminate immediately allowing the
+command to be executed in the background outside of ABS. This means that the
+command must either terminate on its own or be killed using `pkill` or similar.
+This way an ABS script can launch a true daemon process that may never terminate.
+
+For example, an ABS script might also be used to marshall the command line args
+for an interactive program such as the nano editor:
+
+``` bash
+$ cat abs/tests/test-exec.abs
+# marshall the args for the nano editor
+# if the filename is not given in the args, prompt for it
+# if the file is located outside the user's home dir, invoke sudo nano filename
+
+cmd = 'nano'
+filename = arg(2)
+homedir = env("HOME")
+
+while filename == '' {
+    echo("Please enter file name for %s: ", cmd)
+    filename = stdin()
+}
+
+if filename.prefix('~/') || filename.prefix(homedir) {
+    sudo = ''
+} else {
+    sudo = 'sudo'
+}
+
+# execute the command with live stdIO
+exec("$sudo $cmd $filename")
+```
+
 ## Next
 
 That's about it for this section!

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -1085,7 +1085,7 @@ func evalCommandExpression(tok token.Token, cmd string, env *object.Environment)
 	cmd = strings.Trim(cmd, " ")
 
 	// interpolate any $vars in the cmd string
-	cmd = util.InterpolateCmdVars(cmd, env)
+	cmd = util.InterpolateStringVars(cmd, env)
 
 	// A background command ends with a '&'
 	background := len(cmd) > 1 && cmd[len(cmd)-1] == '&'

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -325,9 +325,10 @@ func getFns() map[string]*object.Builtin {
 			Types: []string{object.STRING_OBJ},
 			Fn:    sourceFn,
 		},
+		// exec(command) -- execute command with interactive stdIO
 		"exec": &object.Builtin{
 			Types: []string{object.STRING_OBJ},
-			Fn:    runFn,
+			Fn:    execFn,
 		},
 	}
 }
@@ -1553,8 +1554,8 @@ func sourceFn(tok token.Token, args ...object.Object) object.Object {
 	return evaluated
 }
 
-func runFn(tok token.Token, args ...object.Object) object.Object {
-	err := validateArgs(tok, "run", args, 1, [][]string{{object.STRING_OBJ}})
+func execFn(tok token.Token, args ...object.Object) object.Object {
+	err := validateArgs(tok, "exec", args, 1, [][]string{{object.STRING_OBJ}})
 	if err != nil {
 		return err
 	}

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -329,6 +329,10 @@ func getFns() map[string]*object.Builtin {
 			Types: []string{object.STRING_OBJ},
 			Fn:    runFn,
 		},
+		"exec": &object.Builtin{
+			Types: []string{object.STRING_OBJ},
+			Fn:    runFn,
+		},
 	}
 }
 
@@ -1570,9 +1574,9 @@ func runFn(tok token.Token, args ...object.Object) object.Object {
 		commands = []string{"/C", cmd}
 		executor = "cmd.exe"
 	} else { //assume it's linux, darwin, freebsd, openbsd, solaris, etc
-		// invoke bash commands with login and interactive options (-li) --
-		// this allows the use of aliases and commands in $PATH
-		commands = []string{"-lic", cmd}
+		// invoke bash commands with login option (-l) --
+		// this allows the use of commands in $PATH
+		commands = []string{"-lc", cmd}
 		executor = "bash"
 	}
 	// set up command to execute using our stdIO
@@ -1588,7 +1592,7 @@ func runFn(tok token.Token, args ...object.Object) object.Object {
 	runErr := c.Run()
 
 	if runErr != nil {
-		return err
+		return &object.String{Value: runErr.Error()}
 	}
 	return NULL
 }

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -1563,7 +1563,7 @@ func execFn(tok token.Token, args ...object.Object) object.Object {
 	cmd = strings.Trim(cmd, " ")
 
 	// interpolate any $vars in the cmd string
-	cmd = util.InterpolateCmdVars(cmd, globalEnv)
+	cmd = util.InterpolateStringVars(cmd, globalEnv)
 
 	var commands []string
 	var executor string

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -325,10 +325,6 @@ func getFns() map[string]*object.Builtin {
 			Types: []string{object.STRING_OBJ},
 			Fn:    sourceFn,
 		},
-		"run": &object.Builtin{
-			Types: []string{object.STRING_OBJ},
-			Fn:    runFn,
-		},
 		"exec": &object.Builtin{
 			Types: []string{object.STRING_OBJ},
 			Fn:    runFn,

--- a/tests/test-exec.abs
+++ b/tests/test-exec.abs
@@ -1,0 +1,21 @@
+# marshall the args for the nano editor
+# if the filename is not given in the args, prompt for it
+# if the file is located outside the user's home dir, invoke sudo nano filename
+
+cmd = 'nano'
+filename = arg(2)
+homedir = env("HOME")
+
+while filename == '' {
+    echo("Please enter file name for %s: ", cmd)
+    filename = stdin()
+}
+
+if filename.prefix('~/') || filename.prefix(homedir) {
+    sudo = ''
+} else {
+    sudo = 'sudo'
+}
+
+# execute the command with live stdIO
+exec("$sudo $cmd $filename")

--- a/tests/test-str-interpolate.abs
+++ b/tests/test-str-interpolate.abs
@@ -1,0 +1,44 @@
+#! /usr/local/bin/abs
+
+from_dir = '/var/log'
+to_dir = '/tmp/log'
+pat = '*.log'
+
+# currently: only command strings get $var interpolation
+# this means that bash $vars are not escaped and str.fmt() is the only way to interpolate raw strings (using %formats) 
+cmd = "mkdir -p %s && cd %s && for f in $(ls %s); do echo $f; cp $f %s/$f; done".fmt(to_dir, from_dir, pat, to_dir)
+echo("%q", cmd) # "mkdir -p /tmp/log && cd /var/log && for f in $(ls *.log); do echo $f; cp $f /tmp/log/$f; done"
+$($cmd)
+
+# proposal 1: all string literals get $var interpolation by default
+# this means that all bash $vars must be retrofitted as \$var in existing code which may break due to unknown $vars 
+# note that default $var string interpolation fails in this example because there is no string var f in the abs env
+# also str.fmt() will receive a pre-interpolated string as its format spec -- this may be hard to work around
+cmd = "mkdir -p $to_dir && cd $from_dir && for f in $(ls $pat); do echo \$f; cp \$f $to_dir/\$f; done"
+echo("%q", cmd) # "mkdir -p /tmp/log && cd /var/log && for f in $(ls *.log); do echo $f; cp $f /tmp/log/$f; done"
+$($cmd)
+
+# proposal 2: upgrade str.fmt() to include $var and ${var[:format]} interpolation in addition to %format
+# this means that string literals do not get interpolated by default because str.fmt() needs a raw format spec
+# furthermore, if a $var string object is not found in the abs env, then we would just leave the $var literal in place for bash
+# this would be a primitive, but useful, form of $var namespace separation between abs and bash
+# thus, only if there is a $var namespace collision would \$var be needed to force the $var into the bash namespace
+
+# a) no default interpolation of string literals means no changes needed to legacy abs string parsing code or scripts
+cmd = "mkdir -p $to_dir && cd $from_dir && for f in $(ls $pat); do echo \$f; cp $f $to_dir/$f; done"
+echo("%q", cmd) # "mkdir -p $to_dir && cd $from_dir && for f in $(ls $pat); do echo \$f; cp $f $to_dir/$f; done"
+
+# b) support for $var and ${var[:format]} interpolation via str.fmt() with no args; 
+# unknown $vars in the abs env such as $f are left untouched and are assumed to be in the bash $var namespace
+# escaped \$vars such as \$f are forced into the bash namespace and the escape backslashes are removed
+cmd = cmd.fmt()
+echo("%q", cmd) # "mkdir -p /tmp/log && cd /var/log && for f in $(ls *.log); do echo $f; cp $f /tmp/log/$f; done"
+$($cmd)
+
+# c) support for mixed $var, ${var[:format]} and %format interpolation via str.fmt(args...)
+# this also implies that legacy str.fmt(args...) %format-only strings still work
+cmd = "mkdir -p $to_dir && cd $from_dir && for f in $(ls %s); do echo $f; cp $f $to_dir/$f; done"
+echo("%q", cmd) # "mkdir -p $to_dir && cd $from_dir && for f in $(ls %s); do echo $f; cp $f $to_dir/$f; done"
+cmd = cmd.fmt(pat)
+echo("%q", cmd) # "mkdir -p /tmp/log && cd /var/log && for f in $(ls *.log); do echo $f; cp $f /tmp/log/$f; done"
+$($cmd)

--- a/util/util.go
+++ b/util/util.go
@@ -57,13 +57,13 @@ func GetEnvVar(env *object.Environment, varName, defaultVal string) string {
 	return value
 }
 
-// InterpolateCmdVars (cmd, env)
-// return command string with $vars interpolated from environment
-func InterpolateCmdVars(cmd string, env *object.Environment) string {
+// InterpolateStringVars (str, env)
+// return input string with $vars interpolated from environment
+func InterpolateStringVars(str string, env *object.Environment) string {
 	// Match all strings preceded by
 	// a $ or a \$
 	re := regexp.MustCompile("(\\\\)?\\$([a-zA-Z_]{1,})")
-	cmd = re.ReplaceAllStringFunc(cmd, func(m string) string {
+	str = re.ReplaceAllStringFunc(str, func(m string) string {
 		// If the string starts with a backslash,
 		// that's an escape, so we should replace
 		// it with the remaining portion of the match.
@@ -82,8 +82,7 @@ func InterpolateCmdVars(cmd string, env *object.Environment) string {
 		if !ok {
 			return ""
 		}
-
 		return v.Inspect()
 	})
-	return cmd
+	return str
 }


### PR DESCRIPTION
Here is my proposal for an exec(command) builtin function to solve issue #199.

Considering that implementing a builtin function does not require new lexical support and that exec(command) is similar to what linux C libs provide and the golang exec module supports, it seems to me that this model is reasonably expressive as well as easy to implement.

See tests/test-exec.abs as example of an abs script that marshalls args for a an interactive editor and then executes it with live stdIO. This works in both linux with nano and win10 with notepad. It also works for commands in linux that terminate with & which means we can launch a true daemon process in the background as well.

As a bonus, the $var command string interpolation code has been moved to the util module where it can be shared by regular commands as well as exec commands.