### PR TITLE
Go modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+vendor
 builds/*
 !builds/.gitkeep
 .idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,9 @@ FROM golang:1.12
 
 RUN apt-get update
 RUN apt-get install bash make git curl jq -y
-RUN go get github.com/c-bata/go-prompt
-
-# The aim os to eventually remove these
-RUN go get -v github.com/mattn/go-colorable
-RUN go get -v github.com/mattn/go-tty
-
 ENV CONTEXT=abs
-
-COPY . /go/src/github.com/abs-lang/abs
-WORKDIR /go/src/github.com/abs-lang/abs
-RUN go get -d -v ./...
+COPY . /abs
+WORKDIR /abs
+RUN go mod vendor
 
 CMD bash

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: repl
 run:
-	docker run -ti -v $$(pwd):/go/src/github.com/abs-lang/abs -v /home/`whoami`/.abs_history:/root/.abs_history --name abs --rm abs
+	docker run -ti -v $$(pwd):/abs -v /home/`whoami`/.abs_history:/root/.abs_history --name abs --rm abs
 fmt:
 	go fmt ./...
 build:
@@ -17,9 +17,4 @@ build_simple:
 	go build -o builds/abs main.go
 release: build_simple
 	./builds/abs ./scripts/release.abs
-install:
-	go get github.com/c-bata/go-prompt
-	go get -v github.com/mattn/go-colorable
-	go get -v github.com/mattn/go-tty
-	go get -d -v ./...
-travis: install test
+travis: test

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,12 @@
+module github.com/abs-lang/abs
+
+go 1.12
+
+require (
+	github.com/c-bata/go-prompt v0.2.3
+	github.com/mattn/go-colorable v0.1.1 // indirect
+	github.com/mattn/go-runewidth v0.0.4 // indirect
+	github.com/mattn/go-tty v0.0.0-20190424173100-523744f04859 // indirect
+	github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 // indirect
+	golang.org/x/sys v0.0.0-20190509141414-a5b02f93d862 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/c-bata/go-prompt v0.2.3 h1:jjCS+QhG/sULBhAaBdjb2PlMRVaKXQgn+4yzaauvs2s=
+github.com/c-bata/go-prompt v0.2.3/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
+github.com/mattn/go-colorable v0.1.1 h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=
+github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
+github.com/mattn/go-isatty v0.0.5 h1:tHXDdz1cpzGaovsTB+TVB8q90WEokoVmfMqoVcrLUgw=
+github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
+github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-tty v0.0.0-20190424173100-523744f04859 h1:smQbSzmT3EHl4EUwtFwFGmGIpiYgIiiPeVv1uguIQEE=
+github.com/mattn/go-tty v0.0.0-20190424173100-523744f04859/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
+github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 h1:A7GG7zcGjl3jqAqGPmcNjd/D9hzL95SuoOQAaFNdLU0=
+github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190509141414-a5b02f93d862 h1:rM0ROo5vb9AdYJi1110yjWGMej9ITfKddS89P3Fkhug=
+golang.org/x/sys v0.0.0-20190509141414-a5b02f93d862/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Last week @mingwho introduced me to `go mod` and,
even though this is the 20th attempt at implementing
vendoring/modules in Golang, it looks like this one might
be it.

Mandatory XKCD:

![http://imgs.xkcd.com/comics/standards.png](http://imgs.xkcd.com/comics/standards.png)

:)

This PR converts the `go get` commands in the dockerfile
with a simple `go mod vendor` which downloads all dependencies
locally, in the `vendor` folder.

Added mod and sum files as well to complete the deal.

> Note to self: I might need to fix travis (https://arslan.io/2018/08/26/using-go-modules-with-vendor-support-on-travis-ci/)