### PR TITLE
hash.str() should convert to a valid JSON string, closes #197

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -747,7 +747,7 @@ b
 c")`, []string{"a", "b", "c"}},
 		{`[1, 2].sort()`, []int{1, 2}},
 		{`["b", "a"].sort()`, []string{"a", "b"}},
-		{`["b", 1].sort()`, "argument to `sort` must be an homogeneous array (elements of the same type), got [b, 1]"},
+		{`["b", 1].sort()`, `argument to 'sort' must be an homogeneous array (elements of the same type), got ["b", 1]`},
 		{`[{}].sort()`, "cannot sort an array with given elements elements ([{}])"},
 		{`[[]].sort()`, "cannot sort an array with given elements elements ([[]])"},
 		{`[1, 2].some(f(x) {x == 2})`, true},
@@ -808,7 +808,7 @@ c")`, []string{"a", "b", "c"}},
 		{`"a".str()`, "a"},
 		{`1.str()`, "1"},
 		{`[1].str()`, "[1]"},
-		{`{"a": 10}.str()`, `{a: 10}`},
+		{`{"a": 10}.str()`, `{"a": 10}`},
 		{`"a great movie".title()`, "A Great Movie"},
 		{`"A great movie".lower()`, "a great movie"},
 		{`"A great movie".upper()`, "A GREAT MOVIE"},
@@ -1480,7 +1480,7 @@ z
 		{`
 		a = split("a\nb\nc", "\n")
 		str(a)
-		`, `[a, b, c]`,
+		`, `["a", "b", "c"]`,
 		},
 		{`
 		a = split("a\nb\nc", "\n")
@@ -1513,7 +1513,7 @@ func TestEvalAssignIndex(t *testing.T) {
 		a[5] = 55
 		str(a)
 		`,
-			"[99, 12, string, 4, 88, 55, 66]",
+			`[99, 12, "string", 4, 88, 55, 66]`,
 		},
 		{`
 		h = {"a": 1, "b": 2, "c": 3}
@@ -1525,9 +1525,9 @@ func TestEvalAssignIndex(t *testing.T) {
 		h.d = 99
 		h.d += 1
 		h.z.x = 66
-		h.f = 88
+		h.f = 1.23
 		str(h)
-		`, "{1.23: string, a: 100, b: 2, c: 33, d: 100, e: 55, f: 88, z: {x: 66, y: 20}}",
+		`, `{"1.23": "string", "a": 100, "b": 2, "c": 33, "d": 100, "e": 55, "f": 1.23, "z": {"x": 66, "y": 20}}`,
 		},
 	}
 
@@ -1554,7 +1554,7 @@ func TestHashFunctions(t *testing.T) {
 		hp = pop(h, "c")
 		hp = h.pop("d")
 		str(h)
-		`, "{b: 2}",
+		`, `{"b": 2}`,
 		},
 	}
 

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -869,7 +869,7 @@ func sortFn(tok token.Token, args ...object.Object) object.Object {
 	}
 
 	if !arr.Homogeneous() {
-		return newError(tok, "argument to `sort` must be an homogeneous array (elements of the same type), got %s", arr.Inspect())
+		return newError(tok, "argument to 'sort' must be an homogeneous array (elements of the same type), got %s", arr.Inspect())
 	}
 
 	switch elements[0].(type) {

--- a/object/object.go
+++ b/object/object.go
@@ -54,6 +54,7 @@ type Hashable interface {
 type Object interface {
 	Type() ObjectType
 	Inspect() string
+	Json() string
 }
 
 type Iterable interface {
@@ -78,6 +79,7 @@ func (n *Number) Inspect() string {
 	}
 	return strconv.FormatFloat(n.Value, 'f', -1, 64)
 }
+func (n *Number) Json() string       { return n.Inspect() }
 func (n *Number) ZeroValue() float64 { return float64(0) }
 func (n *Number) Int() int           { return int(n.Value) }
 
@@ -88,6 +90,7 @@ type Boolean struct {
 
 func (b *Boolean) Type() ObjectType { return BOOLEAN_OBJ }
 func (b *Boolean) Inspect() string  { return fmt.Sprintf("%t", b.Value) }
+func (b *Boolean) Json() string     { return b.Inspect() }
 
 type Null struct {
 	Token token.Token
@@ -95,6 +98,7 @@ type Null struct {
 
 func (n *Null) Type() ObjectType { return NULL_OBJ }
 func (n *Null) Inspect() string  { return "null" }
+func (n *Null) Json() string     { return n.Inspect() }
 
 type ReturnValue struct {
 	Token token.Token
@@ -103,6 +107,7 @@ type ReturnValue struct {
 
 func (rv *ReturnValue) Type() ObjectType { return RETURN_VALUE_OBJ }
 func (rv *ReturnValue) Inspect() string  { return rv.Value.Inspect() }
+func (rv *ReturnValue) Json() string     { return rv.Inspect() }
 
 type Error struct {
 	Message string
@@ -110,6 +115,7 @@ type Error struct {
 
 func (e *Error) Type() ObjectType { return ERROR_OBJ }
 func (e *Error) Inspect() string  { return "ERROR: " + e.Message }
+func (e *Error) Json() string     { return e.Inspect() }
 
 type Function struct {
 	Token      token.Token
@@ -136,6 +142,8 @@ func (f *Function) Inspect() string {
 
 	return out.String()
 }
+
+func (f *Function) Json() string { return f.Inspect() }
 
 // The String is a special fella.
 //
@@ -176,6 +184,7 @@ type String struct {
 
 func (s *String) Type() ObjectType  { return STRING_OBJ }
 func (s *String) Inspect() string   { return s.Value }
+func (s *String) Json() string      { return `"` + s.Inspect() + `"` }
 func (s *String) ZeroValue() string { return "" }
 func (s *String) HashKey() HashKey {
 	return HashKey{Type: s.Type(), Value: s.Value}
@@ -266,6 +275,7 @@ type Builtin struct {
 
 func (b *Builtin) Type() ObjectType { return BUILTIN_OBJ }
 func (b *Builtin) Inspect() string  { return "builtin function" }
+func (b *Builtin) Json() string     { return b.Inspect() }
 
 type Array struct {
 	Token    token.Token
@@ -305,12 +315,13 @@ func (ao *Array) Homogeneous() bool {
 func (ao *Array) Empty() bool {
 	return len(ao.Elements) == 0
 }
+
 func (ao *Array) Inspect() string {
 	var out bytes.Buffer
 
 	elements := []string{}
 	for _, e := range ao.Elements {
-		elements = append(elements, e.Inspect())
+		elements = append(elements, e.Json())
 	}
 
 	out.WriteString("[")
@@ -319,6 +330,8 @@ func (ao *Array) Inspect() string {
 
 	return out.String()
 }
+
+func (ao *Array) Json() string { return ao.Inspect() }
 
 type HashPair struct {
 	Key   Object
@@ -343,7 +356,7 @@ func (h *Hash) Inspect() string {
 
 	pairs := []string{}
 	for _, pair := range h.Pairs {
-		pairs = append(pairs, fmt.Sprintf("%s: %s", pair.Key.Inspect(), pair.Value.Inspect()))
+		pairs = append(pairs, fmt.Sprintf(`%s: %s`, pair.Key.Json(), pair.Value.Json()))
 	}
 	// create stable key ordered output
 	sort.Strings(pairs)
@@ -354,6 +367,7 @@ func (h *Hash) Inspect() string {
 
 	return out.String()
 }
+func (h *Hash) Json() string { return h.Inspect() }
 
 // Pretty convoluted logic here we could
 // refactor.


### PR DESCRIPTION
The main issue here is that when we convert to a string, we use the
raw value of the AST object. The raw value for a string is `string`,
but that is not valid json (should be `"string"`).

Therefore, I added a new Json() method on all AST objects that
should return a compatible JSON string, and it's used when we
want to convert an hash (and all its key-values) to strings.

```
⧐  {"string": "value", "array": [1,2,3,{"hash": [1,2,null]}]}.str()

{"array": [1, 2, 3, {"hash": [1, 2, null]}], "string": "value"}
```

As a side effect, converting arrays to a string will now yield a valid JSON as well:

```
# before
⧐  ["hello", "world", 71].str()
[hello, world, 71]

# now
⧐  ["hello", "world", 71].str()
["hello", "world", 71]
```