### PR TITLE
Implicit return values (`null`), closes #217

### DIFF
--- a/docs/syntax/return.md
+++ b/docs/syntax/return.md
@@ -20,6 +20,14 @@ func = f(x) {
 func(9) # 10
 ```
 
+The default value of a `return` is `null`:
+
+```
+if x {
+    return # null
+}
+```
+
 ## Next
 
 That's about it for this section!

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -455,8 +455,11 @@ func TestWhileExpressions(t *testing.T) {
 func TestReturnStatements(t *testing.T) {
 	tests := []struct {
 		input    string
-		expected float64
+		expected interface{}
 	}{
+		{"return;", nil},
+		{"return", nil},
+		{"fn = f() { return }; fn()", nil},
 		{"return 10;", 10},
 		{"return 10; 9;", 10},
 		{"return 2 * 5; 9;", 10},
@@ -497,7 +500,14 @@ fn(10);`,
 
 	for _, tt := range tests {
 		evaluated := testEval(tt.input)
-		testNumberObject(t, evaluated, tt.expected)
+		switch tt.expected.(type) {
+		case int:
+			testNumberObject(t, evaluated, float64(tt.expected.(int)))
+		case nil:
+			testNullObject(t, evaluated)
+		default:
+			panic("should not reach here")
+		}
 	}
 }
 

--- a/examples/implicit_retur_value.abs
+++ b/examples/implicit_retur_value.abs
@@ -1,0 +1,10 @@
+fn = f() {
+    if !flag("value") {
+        return;
+    }
+
+    return flag("value")
+}
+
+echo("Call this script with the flag --value to output it. If the flag is not passed, an implicit return will trigger and 'null' will be printed.")
+echo(fn())

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -210,6 +210,7 @@ func (p *Parser) ParseProgram() *ast.Program {
 		}
 		p.nextToken()
 	}
+
 	return program
 }
 
@@ -327,10 +328,20 @@ func (p *Parser) parseAssignStatement() ast.Statement {
 // return x
 func (p *Parser) parseReturnStatement() *ast.ReturnStatement {
 	stmt := &ast.ReturnStatement{Token: p.curToken}
+	returnToken := p.curToken
 
 	p.nextToken()
 
-	stmt.ReturnValue = p.parseExpression(LOWEST)
+	// return;
+	if p.curTokenIs(token.SEMICOLON) {
+		stmt.ReturnValue = &ast.NullLiteral{Token: p.curToken}
+	} else if p.peekTokenIs(token.RBRACE) || p.peekTokenIs(token.EOF) {
+		// return
+		stmt.ReturnValue = &ast.NullLiteral{Token: returnToken}
+	} else {
+		// return xyz
+		stmt.ReturnValue = p.parseExpression(LOWEST)
+	}
 
 	if p.peekTokenIs(token.SEMICOLON) {
 		p.nextToken()

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -56,6 +56,8 @@ func TestReturnStatements(t *testing.T) {
 		input         string
 		expectedValue interface{}
 	}{
+		{"return", nil},
+		{"return;", nil},
 		{"return 5;", 5},
 		{"return true;", true},
 		{"return foobar;", "foobar"},
@@ -1696,6 +1698,8 @@ func testLiteralExpression(
 		return testIdentifier(t, exp, v)
 	case bool:
 		return testBooleanLiteral(t, exp, v)
+	case nil:
+		return testNullLiteral(t, exp, v)
 	}
 	t.Errorf("type of exp not handled. got=%T", exp)
 	return false
@@ -1799,6 +1803,21 @@ func testBooleanLiteral(t *testing.T, exp ast.Expression, value bool) bool {
 	if bo.TokenLiteral() != fmt.Sprintf("%t", value) {
 		t.Errorf("bo.TokenLiteral not %t. got=%s",
 			value, bo.TokenLiteral())
+		return false
+	}
+
+	return true
+}
+
+func testNullLiteral(t *testing.T, exp ast.Expression, value interface{}) bool {
+	nl, ok := exp.(*ast.NullLiteral)
+	if !ok {
+		t.Errorf("exp not *ast.NullLiteral. got=%T", exp)
+		return false
+	}
+
+	if nl.TokenLiteral() != "null" {
+		t.Errorf("nl.TokenLiteral not %t. got=%s", value, nl.TokenLiteral())
 		return false
 	}
 


### PR DESCRIPTION
This PR makes it possible to skip specifying a
return value, a common scenario when we want to exit,
for example, an IF statement:

```
if something {
  return;
}
```

Note that a value-less return statement needs to end with
a semicolon, else we would need substantial changes to our
lexer in order to carry forward new line breaks. Currently,
line breaks are not passed onto the parser, so the parser
wouldn't know whether to trigger a default return value
based on a line break:

```
if something {
  return # the parser would try to go ahead and parse the '{' as a return value
}
```

This also means there's a tricky behavior (documented in the docs),
as if the user forgets to include a semicolon and the next line contains
a valid expression, the expression will be used as return value:

```
if something {
  return
  1
} # the return value is 1
```

All considered, I think these trade-offs are ok, and rather than
undergoing an extensive refactoring of lexer/parser I would throw
this feature out there and then figure out if the community is too
annoyed by these couple of quirks later on...