### PR TITLE
Fixing hash to JSON conversion

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -1546,7 +1546,7 @@ func TestHashFunctions(t *testing.T) {
 		expected string
 	}{
 		{`
-		h = {"a": 1, "b": 2, "c": {"x": 10, "y":20}}
+		h = {"a": 1, "b": 2, "c": {"x": 10, "y":20}, "e": "\"test"}
 		hk = h.keys()
 		hk = keys(h)
 		hv = h.values()
@@ -1557,7 +1557,7 @@ func TestHashFunctions(t *testing.T) {
 		hp = pop(h, "c")
 		hp = h.pop("d")
 		str(h)
-		`, `{"b": 2}`,
+		`, `{"b": 2, "e": "\"test"}`,
 		},
 	}
 

--- a/object/object.go
+++ b/object/object.go
@@ -184,7 +184,7 @@ type String struct {
 
 func (s *String) Type() ObjectType  { return STRING_OBJ }
 func (s *String) Inspect() string   { return s.Value }
-func (s *String) Json() string      { return `"` + s.Inspect() + `"` }
+func (s *String) Json() string      { return `"` + strings.ReplaceAll(s.Inspect(), `"`, `\"`) + `"` }
 func (s *String) ZeroValue() string { return "" }
 func (s *String) HashKey() HashKey {
 	return HashKey{Type: s.Type(), Value: s.Value}


### PR DESCRIPTION
`"` were not escaped, thus would lead
to invalid json (`{"x": "\"y"}` would become `{"x": ""y"}`)