### PR TITLE
Digits should be allowed in variables, closes #233

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -341,7 +341,7 @@ func (l *Lexer) prevChar(steps int) rune {
 
 func (l *Lexer) readIdentifier() string {
 	position := l.position
-	for isLetter(l.ch) {
+	for isLetter(l.ch) || unicode.IsDigit(l.ch) {
 		l.readChar()
 	}
 	return string(l.input[position:l.position])

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -87,6 +87,9 @@ $111
 1_2e1
 小明
 ❤
+hello_w0rld
+hello1
+hello_
 `
 
 	tests := []struct {
@@ -308,6 +311,9 @@ $111
 		{token.NUMBER, "12e1"},
 		{token.IDENT, "小明"},
 		{token.ILLEGAL, "❤"},
+		{token.IDENT, "hello_w0rld"},
+		{token.IDENT, "hello1"},
+		{token.IDENT, "hello_"},
 		{token.EOF, ""},
 	}
 


### PR DESCRIPTION
An identifier can start with a unicode letter or an underscore,
and can contain a unicode letter, an underscore or digits.