### PR TITLE
Allow negative in expressions, closes #239

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -423,7 +423,7 @@ func evalInfixExpression(
 	case left.Type() == object.HASH_OBJ && right.Type() == object.HASH_OBJ:
 		return evalHashInfixExpression(tok, operator, left, right)
 	case operator == "in":
-		return evalInExpression(left, right)
+		return evalInExpression(tok, left, right)
 	case operator == "==":
 		return nativeBoolToBooleanObject(left == right)
 	case operator == "!=":
@@ -436,31 +436,11 @@ func evalInfixExpression(
 }
 
 func evalBangOperatorExpression(right object.Object) object.Object {
-	switch right {
-	case TRUE:
+	if isTruthy(right) {
 		return FALSE
-	case FALSE:
-		return TRUE
-	case NULL:
-		return TRUE
-	default:
-		switch o := right.(type) {
-		case *object.String:
-			if o.Value == o.ZeroValue() {
-				return TRUE
-			}
-
-			return FALSE
-		case *object.Number:
-			if o.Value == o.ZeroValue() {
-				return TRUE
-			}
-
-			return FALSE
-		default:
-			return FALSE
-		}
 	}
+
+	return TRUE
 }
 
 func evalTildePrefixOperatorExpression(tok token.Token, right object.Object) object.Object {
@@ -575,7 +555,7 @@ func evalStringInfixExpression(
 	}
 
 	if operator == "in" {
-		return evalInExpression(left, right)
+		return evalInExpression(tok, left, right)
 	}
 
 	return newError(tok, "unknown operator: %s %s %s", left.Type(), operator, right.Type())
@@ -616,9 +596,7 @@ func evalHashInfixExpression(
 	return newError(tok, "unknown operator: %s %s %s", left.Type(), operator, right.Type())
 }
 
-func evalInExpression(
-	left, right object.Object,
-) object.Object {
+func evalInExpression(tok token.Token, left, right object.Object) object.Object {
 	var found bool
 
 	switch rightObj := right.(type) {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -1061,6 +1061,8 @@ func TestInExpressions(t *testing.T) {
 		expected interface{}
 	}{
 		{`1 in [1]`, true},
+		{`1 in []`, false},
+		{`!(1 in [])`, true},
 		{`1 in ["1"]`, false},
 		{`"1" in [1]`, false},
 		{`1 in [1, 2]`, true},


### PR DESCRIPTION
In expressions used to return their own object.Boolean.
When we use the bang operator against them we check if
result = object.TRUE or object.FALSE. Since they returned
their own object.Boolean, which is not equal to object.TRUE|FALSE,
negation would fail (always returning false).

With this change I actually got rid of all the checks we do
when evaluating a bang expression and simply rely on the logic
behind `isTruthy`, which will avoid duplication and incoherence
in the future.