### PR TITLE
break and continue inside loops, closes #111

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -89,6 +89,26 @@ func (as *AssignStatement) String() string {
 	return out.String()
 }
 
+type BreakStatement struct {
+	Token token.Token // the 'break' token
+}
+
+func (bs *BreakStatement) expressionNode()      {}
+func (bs *BreakStatement) TokenLiteral() string { return bs.Token.Literal }
+func (bs *BreakStatement) String() string {
+	return "break;"
+}
+
+type ContinueStatement struct {
+	Token token.Token // the 'continue' token
+}
+
+func (cs *ContinueStatement) expressionNode()      {}
+func (cs *ContinueStatement) TokenLiteral() string { return cs.Token.Literal }
+func (cs *ContinueStatement) String() string {
+	return "continue;"
+}
+
 type ReturnStatement struct {
 	Token       token.Token // the 'return' token
 	ReturnValue Expression
@@ -312,11 +332,11 @@ func (ie *WhileExpression) String() string {
 }
 
 type ForInExpression struct {
-	Token    token.Token     // The 'for' token
-	Block    *BlockStatement // The block executed inside the for loop
-	Iterable Expression      // An expression that should return an iterable ([1, 2, 3] or x in 1..10)
-	Key      string
-	Value    string
+	Token       token.Token     // The 'for' token
+	Block       *BlockStatement // The block executed inside the for loop
+	Iterable    Expression      // An expression that should return an iterable ([1, 2, 3] or x in 1..10)
+	Key         string
+	Value       string
 	Alternative *BlockStatement
 }
 

--- a/docs/syntax/for.md
+++ b/docs/syntax/for.md
@@ -97,6 +97,39 @@ echo(k) # "hello world"
 echo(v) # v is not defined
 ```
 
+## break and continue
+
+`break` and `continue` work just as you'd expect:
+the former breaks out of a loop:
+
+``` bash
+test = 0
+for x = 0; x <= 10; x = x + 1 {
+  if x < 10 {
+    break
+  }
+
+  test += x
+}
+
+test # 0
+```
+
+while the later skips to the next execution of the loop:
+
+``` bash
+test = 0
+for x = 0; x <= 10; x = x + 1 {
+  if x < 10 {
+    continue
+  }
+
+  test += x
+}
+
+test # 10
+```
+
 ## For ... else ...
 
 `For` loops can also have `else` clause which executes if 

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -248,6 +248,8 @@ func TestForExpressions(t *testing.T) {
 		input    string
 		expected interface{}
 	}{
+		{`x = 0; for k = 0; k < 11; k = k + 1 { if k < 10 { break; }; x += k }; x`, 0},
+		{`x = 0; for k = 0; k < 11; k = k + 1 { if k < 10 { continue; }; x += k }; x`, 10},
 		{"a = 0; for x = 0; x < 10; x = x + 1 { a = a + 1}; a", 10},
 		{"a = 0; for x = 0; x < y; x = x + 1 { a = a + 1}; a", "identifier not found: y"},
 		{"a = 0; increment = f(x) {x+1}; for x = 0; x < 10; x = increment(x) { a = a + 1}; a", 10},
@@ -325,6 +327,8 @@ func TestForInExpressions(t *testing.T) {
 		input    string
 		expected interface{}
 	}{
+		{`x = 0; for v in 1..10 { if v < 10 { break; }; x += v }; x`, 0},
+		{`x = 0; for v in 1..10 { if v < 10 { continue; }; x += v }; x`, 10},
 		{"a = 1..3; b = 0; c = 0; for x in a { b = x }; for x in a { c = x }; c", 3}, // See: https://github.com/abs-lang/abs/issues/112
 		{"a = 0; for k, x in 1 { a = a + 1}; a", "'1' is a NUMBER, not an iterable, cannot be used in for loop"},
 		{"a = 0; for k, x in 1..10 { a = a + 1}; a", 10},

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -90,6 +90,12 @@ $111
 hello_w0rld
 hello1
 hello_
+for true {
+	break
+}
+for true {
+	continue
+}
 `
 
 	tests := []struct {
@@ -314,6 +320,16 @@ hello_
 		{token.IDENT, "hello_w0rld"},
 		{token.IDENT, "hello1"},
 		{token.IDENT, "hello_"},
+		{token.FOR, "for"},
+		{token.TRUE, "true"},
+		{token.LBRACE, "{"},
+		{token.BREAK, "break"},
+		{token.RBRACE, "}"},
+		{token.FOR, "for"},
+		{token.TRUE, "true"},
+		{token.LBRACE, "{"},
+		{token.CONTINUE, "continue"},
+		{token.RBRACE, "}"},
 		{token.EOF, ""},
 	}
 

--- a/object/object.go
+++ b/object/object.go
@@ -117,6 +117,14 @@ func (e *Error) Type() ObjectType { return ERROR_OBJ }
 func (e *Error) Inspect() string  { return "ERROR: " + e.Message }
 func (e *Error) Json() string     { return e.Inspect() }
 
+type BreakError struct {
+	Error
+}
+
+type ContinueError struct {
+	Error
+}
+
 type Function struct {
 	Token      token.Token
 	Parameters []*ast.Identifier

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -107,6 +107,8 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.LBRACE, p.ParseHashLiteral)
 	p.registerPrefix(token.COMMAND, p.parseCommand)
 	p.registerPrefix(token.COMMENT, p.parseComment)
+	p.registerPrefix(token.BREAK, p.parseBreak)
+	p.registerPrefix(token.CONTINUE, p.parseContinue)
 
 	p.infixParseFns = make(map[token.TokenType]infixParseFn)
 	p.registerInfix(token.DOT, p.parseDottedExpression)
@@ -857,6 +859,14 @@ func (p *Parser) parseCommand() ast.Expression {
 // come in, we can simply ignore them
 func (p *Parser) parseComment() ast.Expression {
 	return nil
+}
+
+func (p *Parser) parseBreak() ast.Expression {
+	return &ast.BreakStatement{Token: p.curToken}
+}
+
+func (p *Parser) parseContinue() ast.Expression {
+	return &ast.ContinueStatement{Token: p.curToken}
 }
 
 func (p *Parser) registerPrefix(tokenType token.TokenType, fn prefixParseFn) {

--- a/token/token.go
+++ b/token/token.go
@@ -78,6 +78,8 @@ const (
 	WHILE    = "WHILE"
 	FOR      = "FOR"
 	IN       = "IN"
+	BREAK    = "BREAK"
+	CONTINUE = "CONTINUE"
 )
 
 type Token struct {
@@ -87,16 +89,18 @@ type Token struct {
 }
 
 var keywords = map[string]TokenType{
-	"f":      FUNCTION,
-	"true":   TRUE,
-	"false":  FALSE,
-	"if":     IF,
-	"else":   ELSE,
-	"return": RETURN,
-	"while":  WHILE,
-	"for":    FOR,
-	"in":     IN,
-	"null":   NULL,
+	"f":        FUNCTION,
+	"true":     TRUE,
+	"false":    FALSE,
+	"if":       IF,
+	"else":     ELSE,
+	"return":   RETURN,
+	"while":    WHILE,
+	"for":      FOR,
+	"in":       IN,
+	"null":     NULL,
+	"break":    BREAK,
+	"continue": CONTINUE,
 }
 
 func LookupIdent(ident string) TokenType {


### PR DESCRIPTION
`break` and `continue` are implemented like regular
errors: they will stop the execution of the block of
code, and will be handled according to their meaning:
a `break` terminates the loop, whereas a `continue`
skips to the next cycle.