### PR TITLE
Support numeric bash arguments in commands

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -1219,12 +1219,18 @@ func TestCommand(t *testing.T) {
 			{"`echo hello world`", "hello world"},
 		}
 	} else {
+		executor := "bash"
+		if runtime.GOOS == "windows" {
+			executor = "cmd.exe"
+		}
+
 		// bash commands
 		tests = []testLine{
 			{`a = "A"; b = "B"; eee = "-e"; $(echo $eee -n $a$a$b$b$c$c)`, "AABB"},
 			{`$(echo -n "123")`, "123"},
 			{`$(echo -n hello world)`, "hello world"},
 			{`$(echo hello world | xargs echo -n)`, "hello world"},
+			{`$(echo \$0)`, executor},
 			{`$(echo \$CONTEXT)`, "abs"},
 			{"a = 'A'; b = 'B'; eee = '-e'; `echo $eee -n $a$a$b$b$c$c`", "AABB"},
 			{"`echo -n '123'`", "123"},

--- a/util/util.go
+++ b/util/util.go
@@ -62,7 +62,7 @@ func GetEnvVar(env *object.Environment, varName, defaultVal string) string {
 func InterpolateStringVars(str string, env *object.Environment) string {
 	// Match all strings preceded by
 	// a $ or a \$
-	re := regexp.MustCompile("(\\\\)?\\$([a-zA-Z_]{1,})")
+	re := regexp.MustCompile("(\\\\)?\\$([a-zA-Z_0-9]{1,})")
 	str = re.ReplaceAllStringFunc(str, func(m string) string {
 		// If the string starts with a backslash,
 		// that's an escape, so we should replace


### PR DESCRIPTION
The code that interpolates variables inside commands did not
support numeric arguments. Updated the regex that looks for values
to interpolate.

@kmptkp this should fix #248 -- can you test it out? I'm attaching fresh Linux builds.

[builds.zip](https://github.com/abs-lang/abs/files/3437917/builds.zip)

