### PR TITLE
Deprecate / "unfavour" the legacy command syntax, closes #220

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@
 
 # The ABS programming language
 
-ABS is a scripting language that works best when you're scripting on
+ABS is a programming language that works best when you're scripting on
 your terminal. It tries to combine the elegance of languages
 such as Python, or Ruby, to the convenience of Bash.
 
 ``` bash
-tz = $(cat /etc/timezone);
+tz = `cat /etc/timezone`
 continent, city = tz.split("/")
 
 echo("Best city in the world?")
@@ -73,7 +73,7 @@ And here's how you could write the same code in ABS:
 
 ``` bash
 # Simple program that fetches your IP and sums it up
-res = $(curl -s 'https://api.ipify.org?format=json');
+res = `curl -s 'https://api.ipify.org?format=json'`
 
 if !res.ok {
   echo("An error occurred: %s", res)

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,12 +21,12 @@
   <img href="https://github.com/abs-lang/abs" alt="undefined" src="https://img.shields.io/github/stars/abs-lang/abs.svg?style=social">
 </p>
 
-ABS is a scripting language that works best when you're scripting on
+ABS is a programming language that works best when you're scripting on
 your terminal. It tries to combine the elegance of languages
 such as Python, or Ruby, to the convenience of Bash.
 
 ``` bash
-tz = $(cat /etc/timezone);
+tz = `cat /etc/timezone`;
 continent, city = tz.split("/")
 
 echo("Best city in the world?")
@@ -48,14 +48,14 @@ in Bash:
 
 ``` bash
 # Simple program that fetches your IP and sums it up
-RES=$(curl -s 'https://api.ipify.org?format=json' || "ERR")
+RES=`curl -s 'https://api.ipify.org?format=json' || "ERR"`
 
 if [ "$RES" = "ERR" ]; then
     echo "An error occurred"
     exit 1
 fi
 
-IP=$(echo $RES | jq -r ".ip")
+IP=`echo $RES | jq -r ".ip"`
 IFS=. read first second third fourth <<EOF
 ${IP##*-}
 EOF
@@ -70,7 +70,7 @@ And here's how you could write the same code in ABS:
 
 ``` bash
 # Simple program that fetches your IP and sums it up
-res = $(curl -s 'https://api.ipify.org?format=json');
+res = `curl -s 'https://api.ipify.org?format=json'`
 
 if !res.ok {
   echo("An error occurred: %s", res)

--- a/docs/introduction/how-to-run-abs-code.md
+++ b/docs/introduction/how-to-run-abs-code.md
@@ -61,7 +61,7 @@ the fly:
 $ abs
 Hello there, welcome to the ABS programming language!
 Type 'quit' when you're done, 'help' if you get lost!
-⧐  ip = $(curl icanhazip.com)
+⧐  ip = `curl icanhazip.com`
 ⧐  ip.ok
 true
 ⧐  ip()

--- a/docs/introduction/why-another-scripting-language.md
+++ b/docs/introduction/why-another-scripting-language.md
@@ -44,7 +44,7 @@ call the API of nba.com in order to retrieve the stats for
 one of last year's NBA games:
 
 ``` bash
-r = $(curl "http://data.nba.net/prod/v1/20170201/0021600732_boxscore.json" -H 'DNT: 1' -H 'Accept-Encoding: gzip, deflate, sdch' -H 'Accept-Language: en' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36' -H 'Accept: */*' -H 'Referer: http://stats.nba.com/' -H 'Connection: keep-alive' --compressed);
+r = `curl "http://data.nba.net/prod/v1/20170201/0021600732_boxscore.json" -H 'DNT: 1' -H 'Accept-Encoding: gzip, deflate, sdch' -H 'Accept-Language: en' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36' -H 'Accept: */*' -H 'Referer: http://stats.nba.com/' -H 'Connection: keep-alive' --compressed`;
 
 if !r.ok {
     echo("Could not fetch game data. Bummer!")
@@ -79,7 +79,7 @@ A sneak-peek at some of the things ABS can elegantly do:
 
 ``` bash
 # Unix pipes work
-ip = $(curl icanhazip.com | tr -d '\n')
+ip = `curl icanhazip.com | tr -d '\n'`
 
 # We now have a string -> "10.10.10.12"
 echo(ip)

--- a/docs/misc/error.md
+++ b/docs/misc/error.md
@@ -21,10 +21,10 @@ $ cat examples/error-parse.abs
 m.a = 'abc'
 
 # this is a command terminated with a semi
-d/d = $(command);
+d/d = `command`;
 
 # this is a command terminated with a LF
-c/c = $(command)
+c/c = `command`
 
 # this is a bad infix operator
 b %% c
@@ -34,9 +34,9 @@ $ abs examples/error-parse.abs
 	no prefix parse function for '=' found
 	[4:5]	m.a = 'abc'
 	no prefix parse function for '=' found
-	[7:5]	d/d = $(command);
+	[7:5]	d/d = `command`;
 	no prefix parse function for '=' found
-	[10:5]	c/c = $(command)
+	[10:5]	c/c = `command`
 	no prefix parse function for '%' found
 	[13:4]	b %% c
 

--- a/docs/misc/technical-details.md
+++ b/docs/misc/technical-details.md
@@ -37,9 +37,9 @@ tests/test-parser.abs
 	no prefix parse function for '=' found
 	[4:5]	m.a = 'abc'
 	no prefix parse function for '=' found
-	[7:5]	d/d = $(command);
+	[7:5]	d/d = `command`;
 	no prefix parse function for '=' found
-	[10:5]	c/c = $(command)
+	[10:5]	c/c = `command`
 	no prefix parse function for '%' found
 	[13:4]	b %% c
 	no prefix parse function for '&&' found

--- a/examples/basic.abs
+++ b/examples/basic.abs
@@ -1,2 +1,2 @@
-ip = $(curl -s 'https://api.ipify.org?format=json' | jq -rj ".ip" | awk '{print "[" $1 "]"}');
+ip = `curl -s 'https://api.ipify.org?format=json' | jq -rj ".ip"`
 echo "your ip is " + ip

--- a/examples/city_selector.abs
+++ b/examples/city_selector.abs
@@ -1,4 +1,4 @@
-tz = $(cat /etc/timezone)
+tz = `cat /etc/timezone`
 cont, city = tz.split("/")
 
 echo("Best city in the world?")

--- a/examples/domain_checker.abs
+++ b/examples/domain_checker.abs
@@ -2,7 +2,7 @@
 # Check if a domain is in your hostfile
 echo("What domain are we looking for today?")
 domain = stdin()
-matches = $(cat /etc/hosts | grep $domain | wc -l)
+matches = `cat /etc/hosts | grep $domain | wc -l`
 
 if !matches.ok {
     echo("How do you even...")

--- a/examples/ip-sum.abs
+++ b/examples/ip-sum.abs
@@ -1,4 +1,4 @@
-res = $(curl -s 'https://api.ipify.org?format=json');
+res = `curl -s 'https://api.ipify.org?format=json'`
 
 if !res.ok {
   echo("An error occurred: %s", res)

--- a/examples/ip-sum.sh
+++ b/examples/ip-sum.sh
@@ -1,12 +1,12 @@
 # Simple program that fetches your IP and sums it up
-RES=$(curl -s 'https://api.ipify.org?format=json' || "ERR")
+RES=`curl -s 'https://api.ipify.org?format=json' || "ERR"`
 
 if [ "$RES" = "ERR" ]; then
     echo "An error occurred"
     exit 1
 fi
 
-IP=$(echo $RES | jq -r ".ip")
+IP=`echo $RES | jq -r ".ip"`
 IFS=. read first second third fourth <<EOF
 ${IP##*-}
 EOF

--- a/examples/nba-game.abs
+++ b/examples/nba-game.abs
@@ -1,4 +1,4 @@
-r = $(curl "http://data.nba.net/prod/v1/20170201/0021600732_boxscore.json" -H 'DNT: 1' -H 'Accept-Encoding: gzip, deflate, sdch' -H 'Accept-Language: en' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36' -H 'Accept: */*' -H 'Referer: http://stats.nba.com/' -H 'Connection: keep-alive' --compressed);
+r = `curl "http://data.nba.net/prod/v1/20170201/0021600732_boxscore.json" -H 'DNT: 1' -H 'Accept-Encoding: gzip, deflate, sdch' -H 'Accept-Language: en' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36' -H 'Accept: */*' -H 'Referer: http://stats.nba.com/' -H 'Connection: keep-alive' --compressed`
 
 if !r.ok {
     echo("Could not fetch game data. Bummer!")

--- a/examples/shell_interpolation.abs
+++ b/examples/shell_interpolation.abs
@@ -1,3 +1,3 @@
 var = "/etc"
-out = $(ls -la $var)
+out = `ls -la $var`
 echo(out)

--- a/examples/shell_stdin.abs
+++ b/examples/shell_stdin.abs
@@ -1,3 +1,3 @@
 # echo hello | abs examples/shell_stdin.abs
-out = $(cat)
+out = `cat`
 echo("%s %s", out, "world!")

--- a/object/object.go
+++ b/object/object.go
@@ -166,15 +166,15 @@ func (f *Function) Json() string { return f.Inspect() }
 //
 // So, look at this:
 //
-// cmd = $(ls -la)
+// cmd = `ls -la`
 // type(cmd) // STRING
 // cmd.ok // TRUE
 //
-// cmd = $(curlzzzzz)
+// cmd = `curlzzzzz`
 // type(cmd) // STRING
 // cmd.ok // FALSE
 //
-// cmd = $(sleep 10 &)
+// cmd = `sleep 10 &`
 // type(cmd) // STRING
 // cmd.done // FALSE
 // cmd.wait() // ...

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1043,7 +1043,7 @@ func TestCommandParsing(t *testing.T) {
 	testCommand(t, command, "curl icanhazip.com -X POST")
 }
 
-func TestBacktickParsing(t *testing.T) {
+func TestBacktickCommandParsing(t *testing.T) {
 	input := "`curl icanhazip.com -X POST`"
 
 	l := lexer.New(input)

--- a/scripts/release.abs
+++ b/scripts/release.abs
@@ -45,13 +45,13 @@ platforms = [
 ]
 
 echo("Deleting previous builds...")
-rm = $(rm -rf builds/abs-*)
+rm = `rm -rf builds/abs-*`
 
 if !rm.ok {
     return echo("error: " + rm)
 }
 
-version = $(cat ./main.go | grep "var Version")
+version = `cat ./main.go | grep "var Version"`
 version = version.slice(15, len(version) - 1)
 echo("Running builds for version %s, confirm by typing \"y\"".fmt(version))
 selection = stdin()
@@ -69,7 +69,7 @@ for platform in platforms {
     }
 
     echo("Building %s %s", goos, goarch)
-    build = $(GOOS=$goos GOARCH=$goarch go build -ldflags="-s -w" -o builds/$output_name main.go)
+    build = `GOOS=$goos GOARCH=$goarch go build -ldflags="-s -w" -o builds/$output_name main.go`
 
     if !build.ok {
         echo("error: " + build)

--- a/tests/test-abs.sh
+++ b/tests/test-abs.sh
@@ -2,7 +2,7 @@
 # test the abs parser and eval error location
 
 DIR=~/go/src/github.com/abs-lang/abs
-ABS=$(command -v abs)
+ABS=`command -v abs`
 
 DEBUG=$1
 


### PR DESCRIPTION
The `$()` syntax for commands is cool and works ok,
but presents issues with parsing and escaping. With
this PR this syntax has been removed from most of the
docs, replaced by the simpler backtick commands.

Since `$()` is still useful for embedding commands,
we kept a section of the docs dedicated to explaining
when you should use this vs backticks.