### PR TITLE
Index ranges, closes #138

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -492,10 +492,18 @@ func (al *ArrayLiteral) String() string {
 	return out.String()
 }
 
+// IndexExpression allows accessing a single index, or a range,
+// over a string or an array.
+//
+// array[1:10]	-> left[index:end]
+// array[1] 	-> left[index]
+// string[1] 	-> left[index]
 type IndexExpression struct {
-	Token token.Token // The [ token
-	Left  Expression
-	Index Expression
+	Token   token.Token // The [ token
+	Left    Expression  // the argument on which the index is access eg array of array[1]
+	Index   Expression  // the left-most index eg. 1 in array[1] or array[1:10]
+	IsRange bool        // whether the expression is a range (1:10)
+	End     Expression  // the end of the range, if the expression is a range
 }
 
 func (ie *IndexExpression) expressionNode()      {}
@@ -506,7 +514,13 @@ func (ie *IndexExpression) String() string {
 	out.WriteString("(")
 	out.WriteString(ie.Left.String())
 	out.WriteString("[")
-	out.WriteString(ie.Index.String())
+
+	if ie.IsRange {
+		out.WriteString(ie.Index.String() + ":" + ie.End.String())
+	} else {
+		out.WriteString(ie.Index.String())
+	}
+
 	out.WriteString("])")
 
 	return out.String()

--- a/docs/types/array.md
+++ b/docs/types/array.md
@@ -24,6 +24,30 @@ array[3]
 
 Accessing an index that does not exist returns null.
 
+You can also access a range of indexes with the `[start:end]` notation:
+
+``` bash
+array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+array[0:2] // [0, 1, 2]
+```
+
+where `start` is the starting position in the array, and `end` is
+the ending one. If `start` is not specified, it is assumed to be 0,
+and if `end` is omitted it is assumed to be the last index in the
+array:
+
+``` bash
+array[:2] // [0, 1, 2]
+array[7:] // [7, 8, 9]
+```
+
+If `end` is negative, it will be converted to `length of array - end`:
+
+``` bash
+array[:-3] // [0, 1, 2, 3, 4, 5, 6]
+```
+
 To concatenate arrays, "sum" them:
 
 ``` bash

--- a/docs/types/string.md
+++ b/docs/types/string.md
@@ -34,6 +34,27 @@ with the index notation:
 
 Accessing an index that does not exist returns null.
 
+You can also access a range of the string with the `[start:end]` notation:
+
+``` bash
+"string"[0:3] // "str"
+```
+
+where `start` is the starting position in the array, and `end` is
+the ending one. If `start` is not specified, it is assumed to be 0,
+and if `end` is omitted it is assumed to be the character in the string:
+
+``` bash
+"string"[0:3] // "str"
+"string"[1:] // "tring"
+```
+
+If `end` is negative, it will be converted to `length of string - end`:
+
+``` bash
+"string"[0:-1] // "strin"
+```
+
 To concatenate strings, "sum" them:
 
 ``` bash
@@ -382,6 +403,10 @@ Returns the last index at which `str` is found:
 ```
 
 ### slice(start, end)
+
+> This function is deprecated and might be removed in future versions.
+>
+> Use the index notation instead: `"string"[0, 3]`
 
 Returns a portion of the string, from `start` to `end`:
 

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -1345,6 +1345,38 @@ func TestArrayIndexExpressions(t *testing.T) {
 			"[1, 2, 3][-1]",
 			nil,
 		},
+		{
+			"a = [1, 2, 3, 4, 5, 6, 7, 8, 9][1:-300]; a[0]",
+			nil,
+		},
+		{
+			"a = [1, 2, 3, 4, 5, 6, 7, 8, 9][1:4]; a[0] + a[1] + a[2]",
+			9,
+		},
+		{
+			"a = [1, 2, 3, 4, 5, 6, 7, 8, 9][1:4]; a.len()",
+			3,
+		},
+		{
+			"a = [1, 2, 3, 4, 5, 6, 7, 8, 9][200:3]; a[0]",
+			nil,
+		},
+		{
+			"a = [1, 2, 3, 4, 5, 6, 7, 8, 9][7:-1]; a[0]",
+			8,
+		},
+		{
+			"a = [1, 2, 3, 4, 5, 6, 7, 8, 9][100:]; a[0]",
+			nil,
+		},
+		{
+			"a = [1, 2, 3, 4, 5, 6, 7, 8, 9][0:100]; a[0]",
+			1,
+		},
+		{
+			"a = [1, 2, 3, 4, 5, 6, 7, 8, 9][-10:]; a[0]",
+			1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1447,15 +1479,57 @@ func TestStringIndexExpressions(t *testing.T) {
 			`"123"[1]`,
 			"2",
 		},
+		{
+			`"123"[1:]`,
+			"23",
+		},
+		{
+			`"123"[1:1]`,
+			"",
+		},
+		{
+			`"123"[:2]`,
+			"12",
+		},
+		{
+			`"123"[:-1]`,
+			"12",
+		},
+		{
+			`"123"[2:-10]`,
+			"",
+		},
+		{
+			`"123"[2:1]`,
+			"",
+		},
+		{
+			`"123"[200:]`,
+			"",
+		},
+		{
+			`"123"[0:10]`,
+			"123",
+		},
+		{
+			`"123"[-10:]`,
+			"123",
+		},
+		{
+			`"123"[-10:{}]`,
+			`index ranges can only be numerical: got "{}" (type HASH)`,
+		},
 	}
 
 	for _, tt := range tests {
 		evaluated := testEval(tt.input)
-		s, ok := tt.expected.(string)
-		if ok {
-			testStringObject(t, evaluated, s)
-		} else {
+		switch result := evaluated.(type) {
+		case *object.Null:
 			testNullObject(t, evaluated)
+		case *object.String:
+			testStringObject(t, evaluated, tt.expected.(string))
+		case *object.Error:
+			logErrorWithPosition(t, result.Message, tt.expected)
 		}
 	}
 }

--- a/examples/index_ranges.abs
+++ b/examples/index_ranges.abs
@@ -1,0 +1,4 @@
+str = "Hello world!"
+
+echo(str[:5]) // Hello
+echo(str.split("")[:5]) // ["H", "e", "l", "l", "o"]

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -96,6 +96,7 @@ for true {
 for true {
 	continue
 }
+a[1:3]
 `
 
 	tests := []struct {
@@ -330,6 +331,12 @@ for true {
 		{token.LBRACE, "{"},
 		{token.CONTINUE, "continue"},
 		{token.RBRACE, "}"},
+		{token.IDENT, "a"},
+		{token.LBRACKET, "["},
+		{token.NUMBER, "1"},
+		{token.COLON, ":"},
+		{token.NUMBER, "3"},
+		{token.RBRACKET, "]"},
 		{token.EOF, ""},
 	}
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1352,6 +1352,87 @@ func TestParsingIndexExpressions(t *testing.T) {
 	}
 }
 
+func TestParsingIndexRangeExpressions(t *testing.T) {
+	input := "myArray[99 : 101]"
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
+	indexExp, ok := stmt.Expression.(*ast.IndexExpression)
+	if !ok {
+		t.Fatalf("exp not *ast.IndexExpression. got=%T", stmt.Expression)
+	}
+
+	if !indexExp.IsRange {
+		t.Fatalf("exp is not range")
+	}
+
+	if !testIdentifier(t, indexExp.Left, "myArray") {
+		return
+	}
+
+	testNumberLiteral(t, indexExp.Index, 99)
+	testNumberLiteral(t, indexExp.End, 101)
+}
+
+func TestParsingIndexRangeWithoutStartExpressions(t *testing.T) {
+	input := "myArray[: 101]"
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
+	indexExp, ok := stmt.Expression.(*ast.IndexExpression)
+	if !ok {
+		t.Fatalf("exp not *ast.IndexExpression. got=%T", stmt.Expression)
+	}
+
+	if !indexExp.IsRange {
+		t.Fatalf("exp is not range")
+	}
+
+	if !testIdentifier(t, indexExp.Left, "myArray") {
+		return
+	}
+
+	testNumberLiteral(t, indexExp.Index, 0)
+	testNumberLiteral(t, indexExp.End, 101)
+}
+
+func TestParsingIndexRangeWithoutEndExpressions(t *testing.T) {
+	input := "myArray[99 : ]"
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
+	indexExp, ok := stmt.Expression.(*ast.IndexExpression)
+	if !ok {
+		t.Fatalf("exp not *ast.IndexExpression. got=%T", stmt.Expression)
+	}
+
+	if !testIdentifier(t, indexExp.Left, "myArray") {
+		return
+	}
+
+	if !indexExp.IsRange {
+		t.Fatalf("exp is not range")
+	}
+
+	testNumberLiteral(t, indexExp.Index, 99)
+
+	if indexExp.End != nil {
+		t.Fatalf("range end is not nil. got=%T", indexExp.End)
+	}
+}
+
 func TestParsingProperty(t *testing.T) {
 	input := "var.prop"
 


### PR DESCRIPTION
This PR adds the ability to specify ranges as indexes (`[x]`).
A range is a colon-separated pair of boundaries which can be
either an integer (`[1:10]`) or omitted (`[1:]`).

```
⧐  "Hello world"[0:2]
He
⧐  "Hello world"[0:5]
Hello
⧐  "Hello world"[:5]
Hello
⧐  "Hello world"[5:]
 world
⧐  "Hello world"[:-1]
Hello worl
⧐
```