### PR TITLE
Return values at the end of a script, without semicolon, aren't returned

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -459,7 +459,9 @@ func TestReturnStatements(t *testing.T) {
 	}{
 		{"return;", nil},
 		{"return", nil},
+		{"return 1", 1},
 		{"fn = f() { return }; fn()", nil},
+		{"fn = f() { return 1 }; fn()", 1},
 		{"return 10;", 10},
 		{"return 10; 9;", 10},
 		{"return 2 * 5; 9;", 10},

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -335,7 +335,7 @@ func (p *Parser) parseReturnStatement() *ast.ReturnStatement {
 	// return;
 	if p.curTokenIs(token.SEMICOLON) {
 		stmt.ReturnValue = &ast.NullLiteral{Token: p.curToken}
-	} else if p.peekTokenIs(token.RBRACE) || p.peekTokenIs(token.EOF) {
+	} else if p.curTokenIs(token.RBRACE) || p.curTokenIs(token.EOF) {
 		// return
 		stmt.ReturnValue = &ast.NullLiteral{Token: returnToken}
 	} else {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -58,6 +58,7 @@ func TestReturnStatements(t *testing.T) {
 	}{
 		{"return", nil},
 		{"return;", nil},
+		{"return 5", 5},
 		{"return 5;", 5},
 		{"return true;", true},
 		{"return foobar;", "foobar"},


### PR DESCRIPTION
This fixes a small bug in the code that interprets returns without semicolons,
introduced in `1.6.0`.