### PR TITLE
Number abbreviations

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -47,6 +47,21 @@ func TestEvalFloatExpression(t *testing.T) {
 	}
 }
 
+func TestEvalNumberAbbreviations(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected float64
+	}{
+		{"5k", 5000},
+		{"1m / 1M", 1},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+		testNumberObject(t, evaluated, tt.expected)
+	}
+}
+
 func TestEvalNumberExpression(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -85,6 +85,14 @@ $111
 10_000
 10_00.00
 1_2e1
+12k
+12K
+12m
+12M
+12t
+12T
+12b
+12B
 小明
 ❤
 hello_w0rld
@@ -316,6 +324,14 @@ a[1:3]
 		{token.NUMBER, "10000"},
 		{token.NUMBER, "1000.00"},
 		{token.NUMBER, "12e1"},
+		{token.NUMBER, "12k"},
+		{token.NUMBER, "12K"},
+		{token.NUMBER, "12m"},
+		{token.NUMBER, "12M"},
+		{token.NUMBER, "12t"},
+		{token.NUMBER, "12T"},
+		{token.NUMBER, "12b"},
+		{token.NUMBER, "12B"},
 		{token.IDENT, "小明"},
 		{token.ILLEGAL, "❤"},
 		{token.IDENT, "hello_w0rld"},

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -123,13 +123,16 @@ func TestIdentifierExpression(t *testing.T) {
 
 func TestNumberLiteralExpression(t *testing.T) {
 	prefixTests := []struct {
-		input string
-		value float64
+		input   string
+		value   float64
+		literal string
 	}{
-		{"5;", 5},
-		{"5.5", 5.5},
-		{"5.5555555", 5.5555555},
-		{"5_000", 5000},
+		{"5;", 5, "5"},
+		{"5.5", 5.5, "5.5"},
+		{"5.5555555", 5.5555555, "5.5555555"},
+		{"5_000", 5000, "5000"},
+		{"1k", 1000, "1k"},
+		{"1M", 1000000, "1M"},
 	}
 
 	for _, tt := range prefixTests {
@@ -154,8 +157,8 @@ func TestNumberLiteralExpression(t *testing.T) {
 			t.Errorf("literal.Value not %v. got=%v", tt.value, literal.Value)
 		}
 
-		if literal.TokenLiteral() != fmt.Sprintf("%v", tt.value) {
-			t.Errorf("number.TokenLiteral not %v. got=%s", tt.value, literal.TokenLiteral())
+		if literal.TokenLiteral() != fmt.Sprintf("%v", tt.literal) {
+			t.Errorf("number.TokenLiteral not %v. got=%s", tt.literal, literal.TokenLiteral())
 		}
 	}
 }

--- a/token/token.go
+++ b/token/token.go
@@ -103,6 +103,17 @@ var keywords = map[string]TokenType{
 	"continue": CONTINUE,
 }
 
+// NumberAbbreviations is a list of abbreviations that can be used in numbers eg. 1k, 20B
+var NumberAbbreviations = map[string]float64{
+	"k": 1000,
+	"m": 1000000,
+	"b": 1000000000,
+	"t": 1000000000000,
+}
+
+// NumberSeparator is a separator for numbers eg. 1_000_000
+var NumberSeparator = '_'
+
 func LookupIdent(ident string) TokenType {
 	if tok, ok := keywords[ident]; ok {
 		return tok


### PR DESCRIPTION
This PR adds the ability to abbreviate numbers
by specifying `k`, `m`, `b` or `t` as a suffix to
the number (the suffix is case-insensitive, so
the uppercase counterparts work).

```
1k / 1m # 0.001

1k + 2 # 1002
```