### PR TITLE
Source vs require

### DIFF
--- a/docs/types/builtin-function.md
+++ b/docs/types/builtin-function.md
@@ -259,6 +259,11 @@ available inside it, and vice-versa. The only
 variable available to the caller (the script requiring
 the module) is the module's return value.
 
+Note that `require` uses paths that are relative to
+the current script. Say that you have 2 files (`a.abs` and `b.abs`)
+in the `/tmp` folder, `a.abs` can `require("./b.abs")`
+without having to specify the full path (eg. `require("/tmp/b.abs")`).
+
 ### source(path_to_file.abs)
 
 Evaluates the script at `path_to_file.abs` in the context of the 

--- a/docs/types/builtin-function.md
+++ b/docs/types/builtin-function.md
@@ -229,15 +229,49 @@ Halts the process for as many `ms` you specified:
 sleep(1000) # sleeps for 1 second
 ```
 
-### source(path_to_file) aka require(path_to_file) 
+### require(path_to_file.abs)
 
-Evaluates the script at `path_to_file` in the context of the ABS global
-environment. The results of any expressions in the file become
-available to other commands in the REPL command line or to other
+Evaluates the script at `path_to_file.abs`, and makes
+its return value available to the caller.
+
+For example, suppose we have a `module.abs` file:
+
+``` bash
+adder = f(a, b) { a + b }
+multiplier = f(a, b) { a * b }
+
+return {"adder": adder, "multiplier": multiplier}
+```
+
+and a `main.abs` such as:
+
+``` bash
+mod = require("module.abs")
+
+echo(mod.adder(1, 2)) # 3
+```
+
+This is mostly useful to create external library
+functions, like NPM modules or PIP packages, that
+do not have access to the global environment. Any
+variable set outside of the module will not be
+available inside it, and vice-versa. The only
+variable available to the caller (the script requiring
+the module) is the module's return value.
+
+### source(path_to_file.abs)
+
+Evaluates the script at `path_to_file.abs` in the context of the 
+ABS global environment. The results of any expressions in the file
+become available to other commands in the REPL command line or to other
 scripts in the current script execution chain. 
 
-This is most useful for creating `library functions` in a script
-that can be used by many other scripts. Often the library functions
+This is very similar to `require`, but allows the module to access
+and edit the global environment. Any variable set inside the module
+will also be available outside of it.
+
+This is most useful for creating library functions in a startup script,
+or variables that can be used by many other scripts. Often these library functions
 are loaded via the ABS Init File `~/.absrc` (see [ABS Init File](/introduction/how-to-run-abs-code)).
 
 For example:
@@ -291,6 +325,7 @@ For example an ABS Init File may contain:
 ABS_SOURCE_DEPTH = 15
 source("~/path/to/abs/lib")
 ```
+
 This will limit the source inclusion depth to 15 levels for this
 `source()` statement and will also apply to future `source()`
 statements until changed.

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -26,9 +26,6 @@ var (
 	Fns   map[string]*object.Builtin
 )
 
-// This program's global environment can be used by builtin's to modify the env
-var globalEnv *object.Environment
-
 // This program's lexer used for error location in Eval(program)
 var lex *lexer.Lexer
 
@@ -55,8 +52,6 @@ func newContinueError(tok token.Token, format string, a ...interface{}) *object.
 // REPL and testing modules call this function to init the global lexer pointer for error location
 // NB. Eval(node, env) is recursive
 func BeginEval(program ast.Node, env *object.Environment, lexer *lexer.Lexer) object.Object {
-	// global environment
-	globalEnv = env
 	// global lexer
 	lex = lexer
 	// run the evaluator
@@ -178,7 +173,7 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 			return args[0]
 		}
 
-		return applyFunction(node.Token, function, args)
+		return applyFunction(node.Token, function, env, args)
 
 	case *ast.MethodExpression:
 		o := Eval(node.Object, env)
@@ -191,7 +186,7 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 			return args[0]
 		}
 
-		return applyMethod(node.Token, o, node.Method.String(), args)
+		return applyMethod(node.Token, o, node.Method.String(), env, args)
 
 	case *ast.PropertyExpression:
 		return evalPropertyExpression(node, env)
@@ -1004,7 +999,7 @@ func evalPropertyExpression(pe *ast.PropertyExpression, env *object.Environment)
 	return newError(pe.Token, "invalid property '%s' on type %s", pe.Property.String(), o.Type())
 }
 
-func applyFunction(tok token.Token, fn object.Object, args []object.Object) object.Object {
+func applyFunction(tok token.Token, fn object.Object, env *object.Environment, args []object.Object) object.Object {
 	switch fn := fn.(type) {
 
 	case *object.Function:
@@ -1017,14 +1012,14 @@ func applyFunction(tok token.Token, fn object.Object, args []object.Object) obje
 		return unwrapReturnValue(evaluated)
 
 	case *object.Builtin:
-		return fn.Fn(tok, args...)
+		return fn.Fn(tok, env, args...)
 
 	default:
 		return newError(tok, "not a function: %s", fn.Type())
 	}
 }
 
-func applyMethod(tok token.Token, o object.Object, method string, args []object.Object) object.Object {
+func applyMethod(tok token.Token, o object.Object, method string, env *object.Environment, args []object.Object) object.Object {
 	f, ok := Fns[method]
 
 	if !ok {
@@ -1036,7 +1031,7 @@ func applyMethod(tok token.Token, o object.Object, method string, args []object.
 	}
 
 	args = append([]object.Object{o}, args...)
-	return f.Fn(tok, args...)
+	return f.Fn(tok, env, args...)
 }
 
 func extendFunctionEnv(

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -929,6 +929,10 @@ c")`, []string{"a", "b", "c"}},
 		{`sleep(0.01)`, nil},
 		{`$()`, ""},
 		{`a = 1; eval("a")`, 1},
+		{`"a = 2; return 10" >> "test-source-vs-require.abs.ignore"; a = 1; x = source("test-source-vs-require.abs.ignore"); a`, 2},
+		{`"a = 2; return 10" >> "test-source-vs-require.abs.ignore"; a = 1; x = require("test-source-vs-require.abs.ignore"); a`, 1},
+		{`"a = 2; return 10" >> "test-source-vs-require.abs.ignore"; a = 1; x = source("test-source-vs-require.abs.ignore"); x`, 10},
+		{`"a = 2; return 10" >> "test-source-vs-require.abs.ignore"; a = 1; x = require("test-source-vs-require.abs.ignore"); x`, 10},
 	}
 	for _, tt := range tests {
 		evaluated := testEval(tt.input)

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -1586,7 +1586,7 @@ func TestStringIndexExpressions(t *testing.T) {
 }
 
 func testEval(input string) object.Object {
-	env := object.NewEnvironment(os.Stdout)
+	env := object.NewEnvironment(os.Stdout, "")
 	lex := lexer.New(input)
 	p := parser.New(lex)
 	program := p.ParseProgram()

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -792,7 +792,7 @@ func jsonFn(tok token.Token, env *object.Environment, args ...object.Object) obj
 
 	s := args[0].(*object.String)
 	str := strings.TrimSpace(s.Value)
-	env = object.NewEnvironment(env.Writer)
+	env = object.NewEnvironment(env.Writer, env.Dir)
 	l := lexer.New(str)
 	p := parser.New(l)
 	var node ast.Node
@@ -1567,8 +1567,7 @@ func sourceFn(tok token.Token, env *object.Environment, args ...object.Object) o
 // require("file.abs")
 func requireFn(tok token.Token, env *object.Environment, args ...object.Object) object.Object {
 	file := filepath.Join(env.Dir, args[0].Inspect())
-	e := object.NewEnvironment(env.Writer)
-	e.Dir = filepath.Dir(file)
+	e := object.NewEnvironment(env.Writer, filepath.Dir(file))
 	return doSource(tok, e, file, args...)
 }
 

--- a/examples/ip-finder.abs
+++ b/examples/ip-finder.abs
@@ -1,0 +1,3 @@
+return f() {
+    return `curl icanhazip.com`
+}

--- a/examples/require.abs
+++ b/examples/require.abs
@@ -1,0 +1,7 @@
+ip_finder = require("ip-finder.abs")
+script = require("./second_level/script.abs")
+ip_finder_2 = require("./ip-finder.abs")
+
+echo("My IP is %s", ip_finder())
+echo("The script said '%s'", script())
+echo("My IP is %s", ip_finder_2())

--- a/examples/second_level/hello_module.abs
+++ b/examples/second_level/hello_module.abs
@@ -1,0 +1,1 @@
+return "hello!"

--- a/examples/second_level/script.abs
+++ b/examples/second_level/script.abs
@@ -1,0 +1,5 @@
+hello = require("./hello_module.abs")
+
+return f() {
+    return hello
+}

--- a/js/js.go
+++ b/js/js.go
@@ -23,7 +23,7 @@ func runCode(this js.Value, i []js.Value) interface{} {
 	var buf bytes.Buffer
 	// the first argument to our function
 	code := i[0].String()
-	env := object.NewEnvironment(&buf)
+	env := object.NewEnvironment(&buf, "")
 	lex := lexer.New(code)
 	p := parser.New(lex)
 

--- a/object/environment.go
+++ b/object/environment.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"io"
+	"os"
 	"sort"
 )
 
@@ -19,7 +20,8 @@ func NewEnclosedEnvironment(outer *Environment) *Environment {
 // ABS in
 func NewEnvironment(w io.Writer) *Environment {
 	s := make(map[string]Object)
-	return &Environment{store: s, outer: nil, Writer: w}
+	d, _ := os.Getwd()
+	return &Environment{store: s, outer: nil, Writer: w, Dir: d}
 }
 
 // Environment represent the environment associated
@@ -31,6 +33,16 @@ type Environment struct {
 	// Used to capture output. This is typically os.Stdout,
 	// but you could capture in any io.Writer of choice
 	Writer io.Writer
+	// Dir represents the directory from which we're executing code.
+	// It starts as the directory from which we invoke the ABS
+	// executable, but changes when we call require("...") as each
+	// require call resets the dir to its own directory, so that
+	// relative imports work.
+	//
+	// If we have script A and B in /tmp, A can require("B")
+	// wihout having to specify its full absolute path
+	// eg. require("/tmp/B")
+	Dir string
 }
 
 // Get returns an identifier stored within the environment

--- a/object/environment.go
+++ b/object/environment.go
@@ -2,7 +2,6 @@ package object
 
 import (
 	"io"
-	"os"
 	"sort"
 )
 
@@ -11,17 +10,18 @@ import (
 // new environment has access to identifiers stored
 // in the outer one.
 func NewEnclosedEnvironment(outer *Environment) *Environment {
-	env := NewEnvironment(outer.Writer)
+	env := NewEnvironment(outer.Writer, outer.Dir)
 	env.outer = outer
 	return env
 }
 
 // NewEnvironment creates a new environment to run
-// ABS in
-func NewEnvironment(w io.Writer) *Environment {
+// ABS in, specifying a writer for the output of the
+// program and the base dir (which is used to require
+// other scripts)
+func NewEnvironment(w io.Writer, dir string) *Environment {
 	s := make(map[string]Object)
-	d, _ := os.Getwd()
-	return &Environment{store: s, outer: nil, Writer: w, Dir: d}
+	return &Environment{store: s, outer: nil, Writer: w, Dir: dir}
 }
 
 // Environment represent the environment associated

--- a/object/object.go
+++ b/object/object.go
@@ -13,7 +13,7 @@ import (
 	"github.com/abs-lang/abs/token"
 )
 
-type BuiltinFunction func(tok token.Token, args ...Object) Object
+type BuiltinFunction func(tok token.Token, env *Environment, args ...Object) Object
 
 type ObjectType string
 

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/user"
+	"path/filepath"
 	"strings"
 
 	"github.com/abs-lang/abs/evaluator"
@@ -200,6 +201,10 @@ func BeginRepl(args []string, version string) {
 	} else {
 		interactive = false
 		env.Set("ABS_INTERACTIVE", evaluator.FALSE)
+		// Make sure we set the right Dir when evaluating a script,
+		// so that the script thinks it's running from its location
+		// and things like relative require() calls work.
+		env.Dir = filepath.Dir(args[1])
 	}
 
 	// get abs init file

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -37,7 +37,8 @@ var (
 )
 
 func init() {
-	env = object.NewEnvironment(os.Stdout)
+	d, _ := os.Getwd()
+	env = object.NewEnvironment(os.Stdout, d)
 }
 
 func completer(d prompt.Document) []prompt.Suggest {


### PR DESCRIPTION
Now `require` is not an alias of `source` aymore.

`source`, like in bash, imports a script and gives it full
access to the global environment.

`require` instead imports the script, but does not allow it
to read or set variables at the global level. If a required
scripts needs to "pass" variables to the caller, it can simply
`return` them and they will be available to th caller.

Example -- say this is our module, `ip-finder.abs`:

```
return f() {
  return `curl icanhazip.com`
}
```

Then we can simply use it like this:

```
ip_finder = require("ip-finder.abs")

echo("My IP is %s", ip_finder())
```

I have also made an important change while we wait for modules and the ABS package manager to be implemented (cc @mingwho): I've made `require(...)` use paths that are relative to the current script, just like in NodeJS etc.

To illustrate the problem:

```
/A
  /dir/B
  /dir/C
```

Say that A imports B, and B imports C. If you use `source`, B will have to use `source("./dir/C")` as source paths are always relative to the initial execution context.
With `require` B instead can `require("C")` since the import path is always relative to the current script. When @mingwho works on the installer, we'll have to tweak how we locate the required script making sure we can include installed modules.

With these changes, I've also gotten rid of the `globalEnv` variable which is a global we use to access the main ABS execution environment. I replaced it making sure that the env is being passed around as needed.