### PR TITLE
Add abs module installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ builds/*
 !builds/.gitkeep
 .idea/
 .vscode/
+packages.abs.json

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/c-bata/go-prompt v0.2.4-0.20190826134812-0f95e1d1de2e
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-isatty v0.0.9 // indirect
-	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/mattn/go-tty v0.0.0-20190424173100-523744f04859 // indirect
 	github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 // indirect
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9 h1:d5US/mDsogSGW37IV293h//ZFaeajb69h+EHFsv2xGg=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
+github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8BzLR4=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=

--- a/install/install.go
+++ b/install/install.go
@@ -1,0 +1,232 @@
+package install
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func valid(module string) bool {
+	return strings.HasPrefix(module, "github.com/")
+}
+
+func Install(module string) {
+
+	if !valid(module) {
+		fmt.Printf(`Error reading URL. Please use "github.com/USER/REPO" format to install`)
+		return
+	}
+
+	err := getZip(module)
+	if err != nil {
+		return
+	}
+
+	err = unzip(module)
+	if err != nil {
+		fmt.Printf(`Error unpacking: %v`, err)
+		return
+	}
+
+	alias, err := createAlias(module)
+	if err != nil {
+		return
+	}
+
+	fmt.Printf("\nInstall Success. You can use the module with `require(\"%s\")`\n", alias)
+	return
+}
+
+func PrintLoader(done chan int64, message string) {
+	var stop bool = false
+	symbols := []string{"🌑 ", "🌒 ", "🌓 ", "🌔 ", "🌕 ", "🌖 ", "🌗 ", "🌘 "}
+	i := 0
+
+	for {
+		select {
+		case <-done:
+			stop = true
+		default:
+			fmt.Printf("\r" + symbols[i] + " - " + message)
+			time.Sleep(100 * time.Millisecond)
+			i++
+			if i > len(symbols)-1 {
+				i = 0
+			}
+		}
+
+		if stop {
+			break
+		}
+	}
+}
+
+func getZip(module string) error {
+	path := fmt.Sprintf("./vendor/%s", module)
+	// Create all the parent directories if needed
+	err := os.MkdirAll(filepath.Dir(path), 0755)
+
+	if err != nil {
+		fmt.Printf("Error making directory %s\n", err)
+		return err
+	}
+
+	out, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, os.FileMode(0666))
+	if err != nil {
+		fmt.Printf("Error opening file %s\n", err)
+		return err
+	}
+	defer out.Close()
+
+	client := http.Client{
+		Timeout: time.Duration(10 * time.Second),
+	}
+
+	url := fmt.Sprintf("https://%s/archive/master.zip", module)
+
+	done := make(chan int64)
+	go PrintLoader(done, "Downloading archive")
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		fmt.Printf("Error creating new request %s", err)
+		return err
+	}
+
+	resp, err := client.Do(req)
+
+	if err != nil {
+		fmt.Printf("Could not get module: %s\n", err)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		fmt.Errorf("Bad response code: %d", resp.StatusCode)
+		return err
+	}
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		fmt.Printf("Error copying file %s", err)
+		return err
+	}
+	done <- 1
+	return err
+}
+
+// Unzip will decompress a zip archive
+func unzip(module string) error {
+	fmt.Printf("\nUnpacking...")
+	src := fmt.Sprintf("./vendor/%s", module)
+	dest := filepath.Dir(src)
+
+	r, err := zip.OpenReader(src)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	for _, f := range r.File {
+		// Store filename/path for returning and using later on
+		fpath := filepath.Join(dest, f.Name)
+
+		// Check for ZipSlip. More Info: http://bit.ly/2MsjAWE
+		if !strings.HasPrefix(fpath, filepath.Clean(dest)+string(os.PathSeparator)) {
+			return fmt.Errorf("%s: illegal file path", fpath)
+		}
+
+		if f.FileInfo().IsDir() {
+			// Make Folder
+			os.MkdirAll(fpath, 0755)
+			continue
+		}
+
+		// Make File
+		if err = os.MkdirAll(filepath.Dir(fpath), 0755); err != nil {
+			return err
+		}
+
+		outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+		if err != nil {
+			return err
+		}
+
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+
+		_, err = io.Copy(outFile, rc)
+
+		// Close the file without defer to close before next iteration of loop
+		outFile.Close()
+		rc.Close()
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func createAlias(module string) (string, error) {
+	fmt.Printf("\nCreating alias...")
+	f, err := os.OpenFile("./packages.abs.json", os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		fmt.Printf("Could not open alias file %s\n", err)
+		return "", err
+	}
+	defer f.Close()
+
+	b, err := ioutil.ReadAll(f)
+
+	data := make(map[string]string)
+	moduleName := filepath.Base(module)
+	modulePath := fmt.Sprintf("./vendor/%s-master", module)
+
+	// If package.abs.json file is empty
+	if len(b) == 0 {
+		// Appending "master" as Github zip file has "-master" suffix
+		// Add alias key-value pair to file
+		data[moduleName] = modulePath
+
+	} else {
+		err = json.Unmarshal(b, &data)
+		if err != nil {
+			fmt.Printf("Could not unmarshal alias json %s\n", err)
+			return "", err
+		}
+
+		// module already installed and aliased
+		if data[moduleName] == modulePath {
+			return moduleName, nil
+		}
+
+		if data[moduleName] != "" {
+			fmt.Printf("This module could not be aliased because module of same name exists\n")
+			moduleName = module
+			data[moduleName] = modulePath
+		}
+	}
+
+	newData, err := json.MarshalIndent(data, "", "    ")
+	if err != nil {
+		fmt.Printf("Could not marshal alias json when installing module %s\n", err)
+		return "", err
+	}
+
+	_, err = f.WriteAt(newData, 0)
+	if err != nil {
+		fmt.Printf("Could not write to alias file %s\n", err)
+		return "", err
+	}
+	return moduleName, err
+
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/abs-lang/abs/install"
 	"github.com/abs-lang/abs/repl"
 )
 
@@ -16,6 +17,12 @@ func main() {
 		fmt.Println(Version)
 		return
 	}
+
+	if len(args) == 3 && args[1] == "get" {
+		install.Install(args[2])
+		return
+	}
+
 	// begin the REPL
 	repl.BeginRepl(args, Version)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -99,4 +101,18 @@ func UniqueStrings(slice []string) []string {
 		}
 	}
 	return list
+}
+
+func ReadAliasFromFile(path string) (string, error) {
+	var packageAlias map[string]string
+	a, _ := ioutil.ReadFile("./packages.abs.json")
+	err := json.Unmarshal(a, &packageAlias)
+	if err != nil {
+		return path, err
+	}
+
+	if packageAlias[path] != "" {
+		return packageAlias[path], nil
+	}
+	return path, nil
 }


### PR DESCRIPTION
We can run something like `get github.com/hashicorp/go-getter` to install a package into `./vendor` folder. This will create a JSON file `alias` in the current directory containing a mapping of alias and relative path
```
{
    "go-getter" : " ./vendor/github.com/hashicorp/go-getter"
}
```
In an abs script, we can use `g = require("go-getter")` to use the package

Update:
The current implementation uses https protocol to get a zip file from Github repository and unzips it under the `/vendor` directory. 
The unzip file part is copied from https://golangcode.com/unzip-files-in-go/
Some parts are a bit hack-ish. We can discuss further.