### PR TITLE
This PR re-aligns go-prompt to the original repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/abs-lang/abs
 go 1.12
 
 require (
-	github.com/c-bata/go-prompt v0.2.4-0
+	github.com/c-bata/go-prompt v0.2.4-0.20190826134812-0f95e1d1de2e
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-isatty v0.0.9 // indirect
 	github.com/mattn/go-runewidth v0.0.4 // indirect
@@ -11,5 +11,3 @@ require (
 	github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 // indirect
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 )
-
-replace github.com/c-bata/go-prompt => github.com/odino/go-prompt v0.2.4-0.20190816001457-ea717205ca73412c085f2b2296f11c674f359f5c

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/c-bata/go-prompt v0.2.4-0.20190826134812-0f95e1d1de2e h1:wISxI1PW3d8yWV0aY+Vxwzt56LD+SlMiLWXwNgtdGTU=
+github.com/c-bata/go-prompt v0.2.4-0.20190826134812-0f95e1d1de2e/go.mod h1:Fd2OKZ3h6UdKxcSflqFDkUpTbTKwrtLbvtCp3eVuTEs=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/repl/reverse_search.go
+++ b/repl/reverse_search.go
@@ -9,7 +9,7 @@ import (
 var reverseSearchStr string
 var lastSearchPosition int
 
-func clearReverseSearch() {
+func clearReverseSearch(p *prompt.Document) {
 	reverseSearchStr = ""
 	initReverseSearch()
 }


### PR DESCRIPTION
We have been operating a fork due to #265. Now that https://github.com/c-bata/go-prompt/pull/140 has been merged we don't need the fork anymore.