### PR TITLE
array.tsv(), closes #279

### DIFF
--- a/docs/types/array.md
+++ b/docs/types/array.md
@@ -298,6 +298,47 @@ Sums the elements of the array. Only supported on arrays of numbers:
 [1, 1, 1].sum() # 3
 ```
 
+### tsv([separator], [header])
+
+Formats the array into TSV:
+
+``` bash
+[["LeBron", "James"], ["James", "Harden"]].tsv()
+LeBron	James
+James	Harden
+```
+
+You can also specify the separator to be used if you
+prefer not to use tabs:
+
+``` bash
+[["LeBron", "James"], ["James", "Harden"]].tsv(",")
+LeBron,James
+James,Harden
+```
+
+The input array needs to be an array of arrays or hashes. If
+you use hashes, their keys will be used as heading of the TSV:
+
+```bash
+[{"name": "Lebron", "last": "James", "jersey": 23}, {"name": "James", "last": "Harden"}].tsv()
+jersey	last	name
+23	James	Lebron
+null	Harden	James
+```
+
+The heading will, by default, be a combination of all keys present in the hashes,
+sorted alphabetically. If a key is missing in an hash, `null` will be used as value.
+If you wish to specify the output format, you can pass a list of keys to be used
+as header:
+
+```bash
+[{"name": "Lebron", "last": "James", "jersey": 23}, {"name": "James", "last": "Harden"}].tsv("\t", ["name", "last", "jersey", "additional_key"])
+name	last	jersey	additional_key
+Lebron	James	23	null
+James	Harden	null	null
+```
+
 ### unique()
 
 Returns an array with unique values:

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -949,6 +949,14 @@ c")`, []string{"a", "b", "c"}},
 		{`"a = 2; return 10" >> "test-source-vs-require.abs.ignore"; a = 1; x = require("test-source-vs-require.abs.ignore"); a`, 1},
 		{`"a = 2; return 10" >> "test-source-vs-require.abs.ignore"; a = 1; x = source("test-source-vs-require.abs.ignore"); x`, 10},
 		{`"a = 2; return 10" >> "test-source-vs-require.abs.ignore"; a = 1; x = require("test-source-vs-require.abs.ignore"); x`, 10},
+		{`[[1,2,3], [2,3,4]].tsv()`, "1\t2\t3\n2\t3\t4"},
+		{`[1].tsv()`, "tsv() must be called on an array of arrays or objects, such as [[1, 2, 3], [4, 5, 6]], '[1]' given"},
+		{`[{"c": 3, "b": "hello"}, {"b": 20, "c": 0}].tsv()`, "b\tc\nhello\t3\n20\t0"},
+		{`[[1,2,3], [2,3,4]].tsv(",")`, "1,2,3\n2,3,4"},
+		{`[[1,2,3], [2]].tsv(",")`, "1,2,3\n2"},
+		{`[[1,2,3], [2,3,4]].tsv("abc")`, "1a2a3\n2a3a4"},
+		{`[[1,2,3], [2,3,4]].tsv("")`, "the separator argument to the tsv() function needs to be a valid character, '' given"},
+		{`[{"c": 3, "b": "hello"}, {"b": 20, "c": 0}].tsv("\t", ["c", "b", "a"])`, "c\tb\ta\n3\thello\tnull\n0\t20\tnull"},
 	}
 	for _, tt := range tests {
 		evaluated := testEval(tt.input)

--- a/object/object.go
+++ b/object/object.go
@@ -304,6 +304,9 @@ func (ao *Array) Next() (Object, Object) {
 func (ao *Array) Reset() {
 	ao.position = 0
 }
+
+// Homogeneous returns whether the array is homogeneous,
+// meaning all of its elements are of a single type
 func (ao *Array) Homogeneous() bool {
 	if ao.Empty() {
 		return true

--- a/util/util.go
+++ b/util/util.go
@@ -86,3 +86,17 @@ func InterpolateStringVars(str string, env *object.Environment) string {
 	})
 	return str
 }
+
+// UniqueStrings takes an input list of strings
+// and returns a version without duplicate values
+func UniqueStrings(slice []string) []string {
+	keys := make(map[string]bool)
+	list := []string{}
+	for _, entry := range slice {
+		if _, value := keys[entry]; !value {
+			keys[entry] = true
+			list = append(list, entry)
+		}
+	}
+	return list
+}


### PR DESCRIPTION
Arrays can now easily be formatted as TSV / CSV content:

```
array.tsv()
array.tsv(",")
```

Here are some samples:

```
⧐  [["LeBron", "James"], ["James", "Harden"]].tsv()
LeBron	James
James	Harden

⧐  [{"name": "Lebron", "last": "James", "jersey": 23}, {"name": "James", "last": "Harden"}].tsv("\t", ["name", "last", "jersey", "additional_key"])
name	last	jersey	additional_key
Lebron	James	23	null
James	Harden	null	null
```

There is some complexity in this function due to the fact that
we have to support custom headers, as well as the fact that we
can both format arrays of objects as well as hashes.