### PR TITLE
Functions attached to hashes can now be called, fixes #284

### DIFF
--- a/docs/installer.sh
+++ b/docs/installer.sh
@@ -27,7 +27,7 @@ if [ "${MACHINE_TYPE}" = 'x86_64' ]; then
   ARCH="amd64"
 fi
 
-VERSION=1.8.0
+VERSION=1.8.1
 
 echo "Trying to detect the details of your architecture."
 echo ""

--- a/docs/misc/3pl.md
+++ b/docs/misc/3pl.md
@@ -66,7 +66,7 @@ another file is specified:
 
 ```
 $ ~/projects/abs/builds/abs                                          
-Hello alex, welcome to the ABS (1.8.0) programming language!
+Hello alex, welcome to the ABS (1.8.1) programming language!
 Type 'quit' when you're done, 'help' if you get lost!
 
 ⧐  require("abs-sample-module")

--- a/docs/types/builtin-function.md
+++ b/docs/types/builtin-function.md
@@ -290,7 +290,7 @@ $ cat ~/.absrc
 source("~/abs/lib/library.abs")
 
 $ abs
-Hello user, welcome to the ABS (1.8.0) programming language!
+Hello user, welcome to the ABS (1.8.1) programming language!
 Type 'quit' when you are done, 'help' if you get lost!
 ⧐ adder(1, 2)
 3

--- a/docs/types/hash.md
+++ b/docs/types/hash.md
@@ -93,6 +93,7 @@ h # {a: 1, b: 2, c: {x: 10, y: 20}, z: {xx: 11, yy: 21}}
 ## Supported functions
 
 ### str()
+
 Returns the string representation of the hash:
 
 ``` bash
@@ -102,6 +103,7 @@ str(h)  # "{k: v}"
 ```
 
 ### keys()
+
 Returns an array of keys to the hash. 
 
 Note well that only the first level keys are returned.
@@ -113,6 +115,7 @@ keys(h) # [a, b, c]
 ```
 
 ### values()
+
 Returns an array of values in the hash. 
 
 Note well that only the first level values are returned.
@@ -124,6 +127,7 @@ values(h)   # [1, 2, 3]
 ```
 
 ### items()
+
 Returns an array of [key, value] tuples for each item in the hash.
 
 Note well that only the first level items are returned.
@@ -135,6 +139,7 @@ items(h)    # [[a, 1], [b, 2], [c, 3]]
 ```
 
 ### pop(k)
+
 Removes and returns the matching `{"key": value}` item from the hash. If the key does not exist `hash.pop("key")` returns `null`.
 
 Note well that only the first level items can be popped.
@@ -153,6 +158,15 @@ h   # {b: 2}
 
 ```
 
+## User-defined functions
+
+A useful property of being able to assign keys of any type to an hash
+results in the ability to define objects with custom functions, such as:
+
+``` bash
+hash = {"greeter": f(name) { return "Hello $name!" }}
+hash.greeter("Sally") # "Hello Sally!"
+```
 
 ## Next
 

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/abs-lang/abs/repl"
 )
 
-var Version = "1.8.0"
+var Version = "1.8.1"
 
 // The ABS interpreter
 func main() {

--- a/object/object.go
+++ b/object/object.go
@@ -362,6 +362,18 @@ func (h *Hash) GetPair(key string) (HashPair, bool) {
 	return record, ok
 }
 
+// GetKeyType returns the type of a given key in the hash.
+// If no key is found, it is considered to be a NULL.
+func (h *Hash) GetKeyType(k string) ObjectType {
+	pair, ok := h.GetPair(k)
+
+	if !ok {
+		return NULL_OBJ
+	}
+
+	return pair.Value.Type()
+}
+
 func (h *Hash) Inspect() string {
 	var out bytes.Buffer
 


### PR DESCRIPTION
Previously, if an hash had a function defined (ie. `obj = {"fn": f(){ return "hello"}}`)
you couldn't directly invoke the function with `obk.fn()` but you had to
"dereference" it first (eg. `fn = obj.fn; fn()`). This has been fixed with
this PR, adding a bunch more tests, relevant docs and preparing for a new
patch release.