### PR TITLE
Optional chaining, closes #296

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -255,6 +255,7 @@ type MethodExpression struct {
 	Object    Expression
 	Method    Expression
 	Arguments []Expression
+	Optional  bool
 }
 
 func (me *MethodExpression) expressionNode()      {}
@@ -268,6 +269,9 @@ func (me *MethodExpression) String() string {
 	}
 
 	out.WriteString(me.Object.String())
+	if me.Optional {
+		out.WriteString("?")
+	}
 	out.WriteString(".")
 	out.WriteString(me.Method.String())
 	out.WriteString("(")
@@ -530,6 +534,7 @@ type PropertyExpression struct {
 	Token    token.Token // The . token
 	Object   Expression
 	Property Expression
+	Optional bool
 }
 
 func (pe *PropertyExpression) expressionNode()      {}
@@ -539,6 +544,11 @@ func (pe *PropertyExpression) String() string {
 
 	out.WriteString("(")
 	out.WriteString(pe.Object.String())
+
+	if pe.Optional {
+		out.WriteString("?")
+	}
+
 	out.WriteString(".")
 	out.WriteString(pe.Property.String())
 	out.WriteString(")")

--- a/docs/syntax/operators.md
+++ b/docs/syntax/operators.md
@@ -230,6 +230,49 @@ true || false # true
 "hello" || "world" # "hello"
 ```
 
+## .
+
+Property accessor, used to access properties or methods of specific variables:
+
+``` bash
+hello = {"to_who": "the world"}
+hello.to_who # "the world"
+```
+
+There are some builtin functions that you can access through the property accessor:
+
+``` bash
+"hello".len() # 5
+```
+
+(a comprehensive list of function is documented in the "*Types and functions*" section of the documentation)
+
+## ?.
+
+Optional chaining operator, used to access properties in a "safe" way.
+
+Given the following object:
+
+``` bash
+test = {"property": 1}
+```
+
+An error would be raised if you were trying to access a non-existing property
+such as `test.something.something_else`:
+
+```
+ERROR: invalid property 'something_else' on type NULL
+	[1:15]	test.something.something_else
+```
+
+Optional chainig prevents those errors from being raised, auto-magically
+converting non-existing properties and methods to `NULL`:
+
+``` bash
+test?.something?.something_else # null
+test?.something?.something_else() # null
+```
+
 ## ..
 
 Range operator, which creates an array from start to end:

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -1503,6 +1503,45 @@ func TestHashLiterals(t *testing.T) {
 	}
 }
 
+func TestOptionalChaining(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{
+			`a = null; a?.b?.c`,
+			nil,
+		},
+		{
+			`a = 1; a?.b?.c`,
+			nil,
+		},
+		{
+			`a = 1; a?.b?.c()`,
+			nil,
+		},
+		{
+			`a = {"b" : {"c": 1}}; a?.b?.c`,
+			1,
+		},
+		{
+			`a = {"b": 1}; a.b`,
+			1,
+		},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+
+		switch evaluated.(type) {
+		case *object.Number:
+			testNumberObject(t, evaluated, float64(tt.expected.(int)))
+		default:
+			testNullObject(t, evaluated)
+		}
+	}
+}
+
 func TestHashIndexExpressions(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -228,6 +228,8 @@ func (l *Lexer) NextToken() token.Token {
 		} else {
 			tok = l.newToken(token.DOT)
 		}
+	case '?':
+		tok = l.newToken(token.QUESTION)
 	case '|':
 		if l.peekChar() == '|' {
 			tok.Type = token.OR

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -105,6 +105,8 @@ for true {
 	continue
 }
 a[1:3]
+a?.b
+a?.b()
 `
 
 	tests := []struct {
@@ -353,6 +355,16 @@ a[1:3]
 		{token.COLON, ":"},
 		{token.NUMBER, "3"},
 		{token.RBRACKET, "]"},
+		{token.IDENT, "a"},
+		{token.QUESTION, "?"},
+		{token.DOT, "."},
+		{token.IDENT, "b"},
+		{token.IDENT, "a"},
+		{token.QUESTION, "?"},
+		{token.DOT, "."},
+		{token.IDENT, "b"},
+		{token.LPAREN, "("},
+		{token.RPAREN, ")"},
 		{token.EOF, ""},
 	}
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1463,6 +1463,62 @@ func TestParsingProperty(t *testing.T) {
 	}
 }
 
+func TestParsingOptionalProperty(t *testing.T) {
+	input := "var?.prop"
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
+	propExpr, ok := stmt.Expression.(*ast.PropertyExpression)
+
+	if !ok {
+		t.Fatalf("exp not *ast.PropertyExpression. got=%T", stmt.Expression)
+	}
+
+	if !testIdentifier(t, propExpr.Object, "var") {
+		return
+	}
+
+	if !testIdentifier(t, propExpr.Property, "prop") {
+		return
+	}
+
+	if propExpr.Optional != true {
+		t.Fatalf("exp is not an optional property")
+	}
+}
+
+func TestParsingOptionalmethod(t *testing.T) {
+	input := "var?.prop()"
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
+	methodExpr, ok := stmt.Expression.(*ast.MethodExpression)
+
+	if !ok {
+		t.Fatalf("exp not *ast.methodExpression. got=%T", stmt.Expression)
+	}
+
+	if !testIdentifier(t, methodExpr.Object, "var") {
+		return
+	}
+
+	if !testIdentifier(t, methodExpr.Method, "prop") {
+		return
+	}
+
+	if methodExpr.Optional != true {
+		t.Fatalf("exp is not an optional property")
+	}
+}
+
 func TestParsingEmptyHashLiteral(t *testing.T) {
 	input := "{}"
 

--- a/token/token.go
+++ b/token/token.go
@@ -66,6 +66,7 @@ const (
 	LBRACKET = "["
 	RBRACKET = "]"
 	DOT      = "."
+	QUESTION = "?"
 	COMMAND  = "$()"
 
 	// Keywords


### PR DESCRIPTION
This PR adds optional chaining to the language, allowing to
access "deep" properties and methods without having to validate
the whole object hierarchy:

```
a.b.c.d.e()
```

would return an error if any step of the way is `null`.

This can be rewritten as:

```
a?.b?.c?.d?.e()
```

and would return `null`, without breaking a script.

Largely inspired by [this](https://chromestatus.com/feature/5668249494618112).