### PR TITLE
added `args()` function

### DIFF
--- a/docs/types/builtin-function.md
+++ b/docs/types/builtin-function.md
@@ -124,6 +124,18 @@ Returns the `n`th argument to the current script:
 arg(0) # /usr/bin/abs
 ```
 
+### args()
+
+Returns the number of arguments to the current script (including the current script itself)
+
+``` bash
+$ abs --flag1 --flag2 arg1 arg2
+Hello user, welcome to the ABS programming language!
+Type 'quit' when you're done, 'help' if you get lost!
+⧐   args()
+5
+```
+
 ### type(var)
 
 Returns the type if the given variable:

--- a/docs/types/builtin-function.md
+++ b/docs/types/builtin-function.md
@@ -126,13 +126,15 @@ arg(0) # /usr/bin/abs
 
 ### args()
 
-Returns the number of arguments to the current script (including the current script itself)
+Returns the list of arguments to the current script (including the current script itself)
 
 ``` bash
 $ abs --flag1 --flag2 arg1 arg2
 Hello user, welcome to the ABS programming language!
 Type 'quit' when you're done, 'help' if you get lost!
 ⧐   args()
+["abs", "--flag1", "--flag2", "arg1", "arg2"]
+⧐   args().len()
 5
 ```
 

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -804,7 +804,10 @@ func TestBuiltinFunctions(t *testing.T) {
 		{`arg("o")`, "argument 0 to arg(...) is not supported (got: o, allowed: NUMBER)"},
 		{`arg(99)`, ""},
 		{`arg(-1)`, ""},
-		{`(0..99).map( f(i) { arg(i) } ).filter( f(i) { i != "" } ).len() == args()`, true},
+		{`(0..99).map( f(i) { arg(i) } ).filter( f(i) { i != "" } ).len() == args().len()`, true},
+		{`arg(0) == args()[0]`, true},
+		{`arg(1) == args()[1]`, true},
+		{`arg(2) == args()[2]`, true},
 		{`pwd().split("").reverse().slice(0, 33).reverse().join("").replace("\\", "/", -1).suffix("/evaluator")`, true}, // Little trick to get travis to run this test, as the base path is not /go/src/
 		{`cwd = cd(); cwd == pwd()`, true},
 		{`cwd = cd("path/to/nowhere"); cwd == pwd()`, false},

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -804,6 +804,7 @@ func TestBuiltinFunctions(t *testing.T) {
 		{`arg("o")`, "argument 0 to arg(...) is not supported (got: o, allowed: NUMBER)"},
 		{`arg(99)`, ""},
 		{`arg(-1)`, ""},
+		{`(0..99).map( f(i) { arg(i) } ).filter( f(i) { i != "" } ).len() == args()`, true},
 		{`pwd().split("").reverse().slice(0, 33).reverse().join("").replace("\\", "/", -1).suffix("/evaluator")`, true}, // Little trick to get travis to run this test, as the base path is not /go/src/
 		{`cwd = cd(); cwd == pwd()`, true},
 		{`cwd = cd("path/to/nowhere"); cwd == pwd()`, false},

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -128,7 +128,7 @@ func getFns() map[string]*object.Builtin {
 		},
 		// args()
 		"args": &object.Builtin{
-			Types: []string{},
+			Types: []string{object.STRING_OBJ},
 			Fn:    argsFn,
 		},
 		// type(variable:"hello")
@@ -734,7 +734,14 @@ func argFn(tok token.Token, env *object.Environment, args ...object.Object) obje
 
 // args()
 func argsFn(tok token.Token, env *object.Environment, args ...object.Object) object.Object {
-	return &object.Number{Token: tok, Value: float64(len(os.Args))}
+	length := len(os.Args)
+	result := make([]object.Object, length, length)
+
+	for i, v := range os.Args {
+		result[i] = &object.String{Token: tok, Value: v}
+	}
+
+	return &object.Array{Elements: result}
 }
 
 // type(variable:"hello")

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -126,6 +126,11 @@ func getFns() map[string]*object.Builtin {
 			Types: []string{object.NUMBER_OBJ},
 			Fn:    argFn,
 		},
+		// args()
+		"args": &object.Builtin{
+			Types: []string{},
+			Fn:    argsFn,
+		},
 		// type(variable:"hello")
 		"type": &object.Builtin{
 			Types: []string{},
@@ -725,6 +730,11 @@ func argFn(tok token.Token, env *object.Environment, args ...object.Object) obje
 	}
 
 	return &object.String{Token: tok, Value: os.Args[i]}
+}
+
+// args()
+func argsFn(tok token.Token, env *object.Environment, args ...object.Object) object.Object {
+	return &object.Number{Token: tok, Value: float64(len(os.Args))}
 }
 
 // type(variable:"hello")


### PR DESCRIPTION
Adds a new `abs` function, `args()`, that returns the number of arguments to the current script, including
the script itself. This is useful for scripts which accept a variable number of positional arguments (for example, a list of files).