### PR TITLE
Index / hash assignments gotchas, closes #315

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -300,6 +300,11 @@ func (p *Parser) parseAssignStatement() ast.Statement {
 			stmt.Value = p.parseExpression(LOWEST)
 			// consume the IndexExpression
 			p.prevIndexExpression = nil
+
+			if p.peekTokenIs(token.SEMICOLON) {
+				p.nextToken()
+			}
+
 			return stmt
 		}
 		if p.prevPropertyExpression != nil {
@@ -309,6 +314,11 @@ func (p *Parser) parseAssignStatement() ast.Statement {
 			stmt.Value = p.parseExpression(LOWEST)
 			// consume the PropertyExpression
 			p.prevPropertyExpression = nil
+
+			if p.peekTokenIs(token.SEMICOLON) {
+				p.nextToken()
+			}
+
 			return stmt
 		}
 	}
@@ -326,6 +336,7 @@ func (p *Parser) parseAssignStatement() ast.Statement {
 	if p.peekTokenIs(token.SEMICOLON) {
 		p.nextToken()
 	}
+
 	return stmt
 }
 


### PR DESCRIPTION
They were not properly handling the case where the final
character is a `;`, when they should "consume" it and move
forward. Instead, the parser would parse the assignment and
move onto the next block, which was a single `;`, causing it
to fail.

A better fix for this could be allowing `;` as valid blocks
that are simply ignore, which would also solve expressions
such as `x = 1;;;`, which are now erroring out.