### PR TITLE
Named functions

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -434,6 +434,43 @@ func (fl *FunctionLiteral) String() string {
 	return out.String()
 }
 
+type Decorator struct {
+	Token     token.Token // @
+	Name      string
+	Arguments []Expression
+	Decorated *FunctionLiteral
+}
+
+func (dc *Decorator) expressionNode()      {}
+func (dc *Decorator) TokenLiteral() string { return dc.Token.Literal }
+func (dc *Decorator) String() string {
+	var out bytes.Buffer
+
+	args := []string{}
+	for _, a := range dc.Arguments {
+		args = append(args, a.String())
+	}
+
+	out.WriteString(dc.TokenLiteral())
+	out.WriteString(dc.Name)
+	out.WriteString("(")
+	out.WriteString(strings.Join(args, ", "))
+	out.WriteString(") ")
+	out.WriteString(dc.Decorated.String())
+
+	return out.String()
+}
+
+type CurrentArgsLiteral struct {
+	Token token.Token // ...
+}
+
+func (cal *CurrentArgsLiteral) expressionNode()      {}
+func (cal *CurrentArgsLiteral) TokenLiteral() string { return cal.Token.Literal }
+func (cal *CurrentArgsLiteral) String() string {
+	return "..."
+}
+
 type CallExpression struct {
 	Token     token.Token // The '(' token
 	Function  Expression  // Identifier or FunctionLiteral

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -410,6 +410,7 @@ func (ce *CommandExpression) String() string {
 
 type FunctionLiteral struct {
 	Token      token.Token // The 'fn' token
+	Name       string      // identifier for this function
 	Parameters []*Identifier
 	Body       *BlockStatement
 }

--- a/docs/_includes/toc.md
+++ b/docs/_includes/toc.md
@@ -25,6 +25,7 @@
 * [Hash](/types/hash)
 * [Functions](/types/function)
 * [Builtin functions](/types/builtin-function)
+* [Decorators](/types/decorator)
 
 ## Miscellaneous
 

--- a/docs/types/builtin-function.md
+++ b/docs/types/builtin-function.md
@@ -353,4 +353,4 @@ statements until changed.
 
 That's about it for this section!
 
-You can now head over to read a little bit about [how to install 3rd party libraries](/misc/3pl).
+You can now head over to read a little bit about [decorators](/types/decorator).

--- a/docs/types/decorator.md
+++ b/docs/types/decorator.md
@@ -1,0 +1,73 @@
+# Decorator
+
+Decorators are a feature built on top of
+ABS' functions -- they're not a type *per se*.
+
+A decorator is a function that "wraps" another
+function, allowing you to enhance the original
+function's functionality with the decorator's
+one.
+
+An example could be a decorator that logs how
+long a function takes to execute, or delays
+execution altogether.
+
+## Declaring decorators
+
+A decorator is a plain-old function that
+accepts `1 + N` arguments, where `1` is the
+function being wrapped, and returns a new
+function that wraps the original one:
+
+```py
+f log_if_slow(original_fn, treshold_ms) {
+    return f() {
+        start = `date +%s%3N`.int()
+        res = original_fn(...)
+        end = `date +%s%3N`.int()
+
+        if end - start > treshold_ms {
+            echo("mmm, we were pretty slow...")
+        }
+
+        return res
+    }
+}
+```
+
+That's as simple as that: a named function 
+that returns a new function that executes the
+decorated one (`original_fn`) and returns its
+result, while logging if it takes longer than
+a few milliseconds.
+
+## Using decorators
+
+Now that we've declared our decorator, it's time
+to use it, through the `@` notation:
+
+```py
+@log_if_slow(500)
+f return_random_number_after_sleeping(seconds) {
+    `sleep $seconds`
+    return rand(1000)
+}
+```
+
+and we can test our decorator has takn the stage:
+
+```console
+⧐  return_random_number_after_sleeping(0)
+493
+⧐  return_random_number_after_sleeping(1)
+mmm, we were pretty slow...
+371
+```
+
+Decorators are heavily inspired by [Python](https://www.python.org/dev/peps/pep-0318/).
+
+## Next
+
+That's about it for this section!
+
+You can now head over to read a little bit about [how to install 3rd party libraries](/misc/3pl).

--- a/docs/types/function.md
+++ b/docs/types/function.md
@@ -32,7 +32,8 @@ Functions must be called with the right number of arguments:
 
 ``` bash
 fn = f(x) { x }
-fn() # ERROR: Wrong number of arguments passed to f(x) {
+fn()
+# ERROR: Wrong number of arguments passed to f(x) {
 # x
 # }. Want [x], got []
 ```
@@ -78,6 +79,31 @@ func = f(x) {
         return x + 1
     }
 }
+```
+
+## Named functions
+
+You can create named functions by specifying an identifier
+after the `f` keyword:
+
+``` bash
+f greeter(name) {
+    echo("Hello $name!")
+}
+
+greeter(`whoami`) # "Hello root!"
+```
+
+As an alternative, you can manually assign
+a function declaration to a variable, though
+this is not the recommended approach:
+
+``` bash
+greeter = f (name) {
+    echo("Hello $name!")
+}
+
+greeter(`whoami`) # "Hello root!"
 ```
 
 ## Supported functions

--- a/docs/types/function.md
+++ b/docs/types/function.md
@@ -106,6 +106,66 @@ greeter = f (name) {
 greeter(`whoami`) # "Hello root!"
 ```
 
+Named functions are the basis of [decorators](/types/decorators).
+
+## Accessing function arguments
+
+Functions can receive a dynamic number of arguments,
+and arguments can be "packed" through the special
+`...` variable:
+
+```py
+f sum_numbers() {
+    s = 0
+    for x in ... {
+        s += x
+    }
+
+    return s
+}
+
+sum_numbers(1) # 1
+sum_numbers(1, 2, 3) # 6
+```
+
+`...` is a special variable that acts
+like an array, so you can loop and slice
+it however you want:
+
+```py
+f first_arg() {
+    if ....len() > 0 {
+        return ...[0]
+    }
+
+    return "No first arg"
+}
+
+first_arg() # "No first arg"
+first_arg(1) # 1
+```
+
+When you pass `...` directly to a function,
+it will be unpacked:
+
+```py
+f echo_wrapper() {
+    echo(...)
+}
+
+echo_wrapper("hello %s", "root") # "hello root"
+```
+
+and you can add additional arguments as well:
+
+```py
+f echo_wrapper() {
+    echo(..., "root")
+}
+
+echo_wrapper("hello %s %s", "sir") # "hello sir root"
+```
+
 ## Supported functions
 
 ### str()

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -92,6 +92,9 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 	case *ast.NullLiteral:
 		return NULL
 
+	case *ast.CurrentArgsLiteral:
+		return &object.Array{Token: node.Token, Elements: env.CurrentArgs, IsCurrentArgs: true}
+
 	case *ast.StringLiteral:
 		return &object.String{Token: node.Token, Value: util.InterpolateStringVars(node.Value, env)}
 
@@ -109,38 +112,7 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 		return evalInfixExpression(node.Token, node.Operator, node.Left, node.Right, env)
 
 	case *ast.CompoundAssignment:
-		left := Eval(node.Left, env)
-		if isError(left) {
-			return left
-		}
-		right := Eval(node.Right, env)
-		if isError(right) {
-			return right
-		}
-		// multi-character operators like "+=" and "**=" are reduced to "+" or "**" for evalInfixExpression()
-		op := node.Operator
-		if len(op) >= 2 {
-			op = op[:len(op)-1]
-		}
-		// get the result of the infix operation
-		expr := evalInfixExpression(node.Token, op, node.Left, node.Right, env)
-		if isError(expr) {
-			return expr
-		}
-		switch nodeLeft := node.Left.(type) {
-		case *ast.Identifier:
-			env.Set(nodeLeft.String(), expr)
-			return NULL
-		case *ast.IndexExpression:
-			// support index assignment expressions: a[0] += 1, h["a"] += 1
-			return evalIndexAssignment(nodeLeft, expr, env)
-		case *ast.PropertyExpression:
-			// support assignment to hash property: h.a += 1
-			return evalPropertyAssignment(nodeLeft, expr, env)
-		}
-		// otherwise
-		env.Set(node.Left.String(), expr)
-		return NULL
+		return evalCompoundAssignment(node, env)
 
 	case *ast.IfExpression:
 		return evalIfExpression(node, env)
@@ -161,13 +133,16 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 		params := node.Parameters
 		body := node.Body
 		name := node.Name
-		fn := &object.Function{Token: node.Token, Parameters: params, Env: env, Body: body, Name: name}
+		fn := &object.Function{Token: node.Token, Parameters: params, Env: env, Body: body, Name: name, Node: node}
 
 		if name != "" {
 			env.Set(name, fn)
 		}
 
 		return fn
+
+	case *ast.Decorator:
+		return evalDecorator(node, env)
 
 	case *ast.CallExpression:
 		function := Eval(node.Function, env)
@@ -176,6 +151,21 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 		}
 
 		args := evalExpressions(node.Arguments, env)
+
+		// Did we pass arguments as ...?
+		// If so, replace arguments with the
+		// environment's CurrentArgs.
+		// If other arguments were passed afterwards
+		// (eg. func(..., x, y)) we also add those.
+		if len(args) > 0 {
+			firstArg, ok := args[0].(*object.Array)
+
+			if ok && firstArg.IsCurrentArgs {
+				newArgs := env.CurrentArgs
+				args = append(newArgs, args[1:]...)
+			}
+		}
+
 		if len(args) == 1 && isError(args[0]) {
 			return args[0]
 		}
@@ -263,6 +253,63 @@ func evalBlockStatement(
 	}
 
 	return result
+}
+
+func evalCompoundAssignment(node *ast.CompoundAssignment, env *object.Environment) object.Object {
+	left := Eval(node.Left, env)
+	if isError(left) {
+		return left
+	}
+	right := Eval(node.Right, env)
+	if isError(right) {
+		return right
+	}
+	// multi-character operators like "+=" and "**=" are reduced to "+" or "**" for evalInfixExpression()
+	op := node.Operator
+	if len(op) >= 2 {
+		op = op[:len(op)-1]
+	}
+	// get the result of the infix operation
+	expr := evalInfixExpression(node.Token, op, node.Left, node.Right, env)
+	if isError(expr) {
+		return expr
+	}
+	switch nodeLeft := node.Left.(type) {
+	case *ast.Identifier:
+		env.Set(nodeLeft.String(), expr)
+		return NULL
+	case *ast.IndexExpression:
+		// support index assignment expressions: a[0] += 1, h["a"] += 1
+		return evalIndexAssignment(nodeLeft, expr, env)
+	case *ast.PropertyExpression:
+		// support assignment to hash property: h.a += 1
+		return evalPropertyAssignment(nodeLeft, expr, env)
+	}
+	// otherwise
+	env.Set(node.Left.String(), expr)
+	return NULL
+}
+
+func evalDecorator(node *ast.Decorator, env *object.Environment) object.Object {
+	decorator, ok := env.Get(node.Name)
+
+	if !ok {
+		return newError(node.Token, "function '%s' is not defined (used as decorator)", node.Name)
+	}
+
+	switch d := decorator.(type) {
+	case *object.Function:
+		fn := Eval(&ast.CallExpression{
+			Function:  d.Node,
+			Arguments: append([]ast.Expression{node.Decorated}, node.Arguments...),
+		}, env)
+
+		env.Set(node.Decorated.Name, fn)
+
+		return decorator
+	default:
+		return newError(node.Token, "decorator '%s' must be a function, %s given", node.Name, decorator.Type())
+	}
 }
 
 // support index assignment expressions: a[0] = 1, h["a"] = 1
@@ -1018,7 +1065,6 @@ func evalPropertyExpression(pe *ast.PropertyExpression, env *object.Environment)
 
 func applyFunction(tok token.Token, fn object.Object, env *object.Environment, args []object.Object) object.Object {
 	switch fn := fn.(type) {
-
 	case *object.Function:
 		extendedEnv, err := extendFunctionEnv(fn, args)
 
@@ -1073,9 +1119,9 @@ func extendFunctionEnv(
 	fn *object.Function,
 	args []object.Object,
 ) (*object.Environment, *object.Error) {
-	env := object.NewEnclosedEnvironment(fn.Env)
+	env := object.NewEnclosedEnvironment(fn.Env, args)
 
-	if len(args) != len(fn.Parameters) {
+	if len(args) < len(fn.Parameters) {
 		return nil, newError(fn.Token, "Wrong number of arguments passed to %s. Want %s, got %s", fn.Inspect(), fn.Parameters, args)
 	}
 

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -160,7 +160,14 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 	case *ast.FunctionLiteral:
 		params := node.Parameters
 		body := node.Body
-		return &object.Function{Token: node.Token, Parameters: params, Env: env, Body: body}
+		name := node.Name
+		fn := &object.Function{Token: node.Token, Parameters: params, Env: env, Body: body, Name: name}
+
+		if name != "" {
+			env.Set(name, fn)
+		}
+
+		return fn
 
 	case *ast.CallExpression:
 		function := Eval(node.Function, env)

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -699,6 +699,8 @@ func TestFunctionApplication(t *testing.T) {
 		input    string
 		expected interface{}
 	}{
+		{"f test() { return 12 }; test()", 12},
+		{"f test(x) { return x }; test(12)", 12},
 		{"identity = f(x) { x; }; identity(5);", 5},
 		{"identity = f(x) { return x; }; identity(5);", 5},
 		{"double = f(x) { x * 2; }; double(5);", 10},
@@ -718,8 +720,10 @@ func TestFunctionApplication(t *testing.T) {
 				continue
 			}
 			logErrorWithPosition(t, errObj.Message, tt.expected)
-		case float64:
+		case int:
 			testNumberObject(t, evaluated, float64(expected))
+		default:
+			t.Fatalf("unhandled type %T", expected)
 		}
 	}
 }

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -429,7 +429,7 @@ func validateVarArgs(tok token.Token, name string, args []object.Object, specs [
 }
 
 func usageVarArgs(name string, specs [][][]string) string {
-	signatures := []string{"Usage:"}
+	signatures := []string{"Wrong arguments passed to '" + name + "'. Usage:"}
 
 	for _, spec := range specs {
 		args := []string{}

--- a/examples/decorators.abs
+++ b/examples/decorators.abs
@@ -1,0 +1,39 @@
+# Function to print
+# the current ts in milliseconds
+f current_ts_milliseconds() {
+    return ` date +%s%3N`.int()
+}
+
+# A decorator that prints execution time of a function
+f timer(fn) {
+    return f() {
+        start = current_ts_milliseconds()
+        fn(...)
+        end = current_ts_milliseconds()
+
+        echo("function took %s milliseconds", end - start)
+    }
+}
+
+# A decorator that sleeps before a function
+f sleeper(fn, duration) {
+    return f() {
+        `sleep $duration`
+        echo("Yawn, I slept for $duration second")
+        fn(...)
+    }
+}
+
+@timer
+f greeter(name) {
+    echo("hello $name")
+}
+
+greeter(`whoami`)
+
+@sleeper(1)
+f greeter(name) {
+    echo("hello $name")
+}
+
+greeter(`whoami`)

--- a/examples/dynamic_variadic_arguments.abs
+++ b/examples/dynamic_variadic_arguments.abs
@@ -1,0 +1,38 @@
+# ... is a special "keyword" to identify
+# the arguments passed to the current function
+
+f breakline() {
+    echo("--------")
+}
+
+f f1() {
+    echo(...)
+}
+
+f1("hello %s", "world")
+
+breakline()
+
+f f2() {
+    echo(....len())
+}
+
+f2(1,2,3,4,5)
+
+breakline()
+
+f f3() {
+    echo(sum(... + [1]))
+}
+
+f3(1)
+
+breakline()
+
+f f4() {
+    for arg in ... {
+        echo(arg)
+    }
+}
+
+f4(1,2,3,4,5)

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -156,6 +156,8 @@ func (l *Lexer) NextToken() token.Token {
 		}
 	case '^':
 		tok = l.newToken(token.BIT_XOR)
+	case '@':
+		tok = l.newToken(token.AT)
 	case '*':
 		if l.peekChar() == '*' {
 			l.readChar()
@@ -220,11 +222,21 @@ func (l *Lexer) NextToken() token.Token {
 	case ',':
 		tok = l.newToken(token.COMMA)
 	case '.':
+		position := l.position
+
 		if l.peekChar() == '.' {
-			tok.Type = token.RANGE
-			tok.Position = l.position
-			tok.Literal = ".."
 			l.readChar()
+
+			if l.peekChar() == '.' {
+				tok.Type = token.CURRENT_ARGS
+				tok.Position = position
+				tok.Literal = "..."
+				l.readChar()
+			} else {
+				tok.Type = token.RANGE
+				tok.Position = position
+				tok.Literal = ".."
+			}
 		} else {
 			tok = l.newToken(token.DOT)
 		}

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -110,6 +110,9 @@ a?.b()
 f hello(x, y) {
 	x + y;
 };
+@decorator
+@decorator()
+...
 `
 
 	tests := []struct {
@@ -382,6 +385,13 @@ f hello(x, y) {
 		{token.SEMICOLON, ";"},
 		{token.RBRACE, "}"},
 		{token.SEMICOLON, ";"},
+		{token.AT, "@"},
+		{token.IDENT, "decorator"},
+		{token.AT, "@"},
+		{token.IDENT, "decorator"},
+		{token.LPAREN, "("},
+		{token.RPAREN, ")"},
+		{token.CURRENT_ARGS, "..."},
 		{token.EOF, ""},
 	}
 

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -107,6 +107,9 @@ for true {
 a[1:3]
 a?.b
 a?.b()
+f hello(x, y) {
+	x + y;
+};
 `
 
 	tests := []struct {
@@ -365,6 +368,20 @@ a?.b()
 		{token.IDENT, "b"},
 		{token.LPAREN, "("},
 		{token.RPAREN, ")"},
+		{token.FUNCTION, "f"},
+		{token.IDENT, "hello"},
+		{token.LPAREN, "("},
+		{token.IDENT, "x"},
+		{token.COMMA, ","},
+		{token.IDENT, "y"},
+		{token.RPAREN, ")"},
+		{token.LBRACE, "{"},
+		{token.IDENT, "x"},
+		{token.PLUS, "+"},
+		{token.IDENT, "y"},
+		{token.SEMICOLON, ";"},
+		{token.RBRACE, "}"},
+		{token.SEMICOLON, ";"},
 		{token.EOF, ""},
 	}
 

--- a/object/environment.go
+++ b/object/environment.go
@@ -9,9 +9,10 @@ import (
 // with another one embedded to it, so that the
 // new environment has access to identifiers stored
 // in the outer one.
-func NewEnclosedEnvironment(outer *Environment) *Environment {
+func NewEnclosedEnvironment(outer *Environment, args []Object) *Environment {
 	env := NewEnvironment(outer.Writer, outer.Dir)
 	env.outer = outer
+	env.CurrentArgs = args
 	return env
 }
 
@@ -29,7 +30,17 @@ func NewEnvironment(w io.Writer, dir string) *Environment {
 // holds all variables etc.
 type Environment struct {
 	store map[string]Object
-	outer *Environment
+	// Arguments this environment was created in.
+	// When we call function(1, 2, 3), a new environment
+	// for the function to execute is created, and 1/2/3
+	// are recorded as arguments for this environment.
+	//
+	// Later, if we need to access the arguments passed
+	// to the function, we can refer back to them
+	// through env.CurrentArgs. This is how ... is
+	// implemented.
+	CurrentArgs []Object
+	outer       *Environment
 	// Used to capture output. This is typically os.Stdout,
 	// but you could capture in any io.Writer of choice
 	Writer io.Writer

--- a/object/object.go
+++ b/object/object.go
@@ -127,6 +127,7 @@ type ContinueError struct {
 
 type Function struct {
 	Token      token.Token
+	Name       string
 	Parameters []*ast.Identifier
 	Body       *ast.BlockStatement
 	Env        *Environment
@@ -142,6 +143,11 @@ func (f *Function) Inspect() string {
 	}
 
 	out.WriteString("f")
+
+	if f.Name != "" {
+		out.WriteString(" " + f.Name)
+	}
+
 	out.WriteString("(")
 	out.WriteString(strings.Join(params, ", "))
 	out.WriteString(") {")

--- a/object/object.go
+++ b/object/object.go
@@ -131,6 +131,7 @@ type Function struct {
 	Parameters []*ast.Identifier
 	Body       *ast.BlockStatement
 	Env        *Environment
+	Node       *ast.FunctionLiteral
 }
 
 func (f *Function) Type() ObjectType { return FUNCTION_OBJ }
@@ -294,7 +295,15 @@ func (b *Builtin) Json() string     { return b.Inspect() }
 type Array struct {
 	Token    token.Token
 	Elements []Object
-	position int
+	// ... is aliased to an array of arguments.
+	//
+	// Since this is a special case of an array,
+	// we need a flag to make sure we know when
+	// to unpack them, else if we do func(...),
+	// func would receive only one array argument
+	// as opposd to the unpacked arguments.
+	IsCurrentArgs bool
+	position      int
 }
 
 func (ao *Array) Type() ObjectType { return ARRAY_OBJ }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -778,6 +778,11 @@ func (p *Parser) parseBlockStatement() *ast.BlockStatement {
 func (p *Parser) parseFunctionLiteral() ast.Expression {
 	lit := &ast.FunctionLiteral{Token: p.curToken}
 
+	if p.peekTokenIs(token.IDENT) {
+		p.nextToken()
+		lit.Name = p.curToken.Literal
+	}
+
 	if !p.expectPeek(token.LPAREN) {
 		return nil
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -112,6 +112,8 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.COMMENT, p.parseComment)
 	p.registerPrefix(token.BREAK, p.parseBreak)
 	p.registerPrefix(token.CONTINUE, p.parseContinue)
+	p.registerPrefix(token.CURRENT_ARGS, p.parseCurrentArgsLiteral)
+	p.registerPrefix(token.AT, p.parseDecorator)
 
 	p.infixParseFns = make(map[token.TokenType]infixParseFn)
 	p.registerInfix(token.QUESTION, p.parseQuestionExpression)
@@ -796,6 +798,61 @@ func (p *Parser) parseFunctionLiteral() ast.Expression {
 	lit.Body = p.parseBlockStatement()
 
 	return lit
+}
+
+// @decorator
+// @decorator(1, 2)
+func (p *Parser) parseDecorator() ast.Expression {
+	dc := &ast.Decorator{Token: p.curToken}
+	// A decorator always preceeds a
+	// named function, so once we're done
+	// with our "own" parsing, we can defer
+	// to the function literal parsing.
+	//
+	// Note that this code does not allow
+	// nested decorators, so we will probably
+	// want to change the implementation at some
+	// point, by "recursively" parsing the next
+	// block and seeing whether they are other
+	// decorators / functions.
+	defer (func() {
+		p.nextToken()
+		exp := p.parseFunctionLiteral()
+
+		switch fn := exp.(type) {
+		case *ast.FunctionLiteral:
+			if fn.Name == "" {
+				p.reportError("a decorator should decorate a named function", dc.Token)
+			}
+
+			dc.Decorated = fn
+		default:
+			p.reportError("a decorator should decorate a named function", dc.Token)
+		}
+	})()
+
+	if p.peekTokenIs(token.IDENT) {
+		p.nextToken()
+		dc.Name = p.curToken.Literal
+	}
+
+	// This is a decorator without arguments
+	// @func
+	if !p.peekTokenIs(token.LPAREN) {
+		return dc
+	}
+
+	// This is a decorator with arguments
+	// @func(x, y, z)
+	p.nextToken()
+	dc.Arguments = p.parseExpressionList(token.RPAREN)
+
+	return dc
+}
+
+// ...
+func (p *Parser) parseCurrentArgsLiteral() ast.Expression {
+	return &ast.CurrentArgsLiteral{Token: p.curToken}
 }
 
 // f(x, y)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1081,10 +1081,12 @@ func TestFunctionParameterParsing(t *testing.T) {
 	tests := []struct {
 		input          string
 		expectedParams []string
+		name           string
 	}{
 		{input: "f() {};", expectedParams: []string{}},
 		{input: "f(x) {};", expectedParams: []string{"x"}},
 		{input: "f(x, y, z) {};", expectedParams: []string{"x", "y", "z"}},
+		{input: "f hello() {};", expectedParams: []string{}, name: "hello"},
 	}
 
 	for _, tt := range tests {
@@ -1097,8 +1099,11 @@ func TestFunctionParameterParsing(t *testing.T) {
 		function := stmt.Expression.(*ast.FunctionLiteral)
 
 		if len(function.Parameters) != len(tt.expectedParams) {
-			t.Errorf("length parameters wrong. want %d, got=%d\n",
-				len(tt.expectedParams), len(function.Parameters))
+			t.Errorf("length parameters wrong. want %d, got=%d\n", len(tt.expectedParams), len(function.Parameters))
+		}
+
+		if tt.name != function.Name {
+			t.Errorf("name parameter wrong. want %s, got=%s\n", tt.name, function.Name)
 		}
 
 		for i, ident := range tt.expectedParams {

--- a/token/token.go
+++ b/token/token.go
@@ -7,11 +7,13 @@ const (
 	EOF     = "EOF"
 
 	// Identifiers + literals
-	IDENT   = "IDENT"  // add, foobar, x, y, ...
-	NUMBER  = "NUMBER" // 1343456, 1.23456
-	STRING  = "STRING" // "foobar"
-	COMMENT = "#"      // # Comment
-	NULL    = "NULL"   // # null
+	IDENT        = "IDENT"  // add, foobar, x, y, ...
+	NUMBER       = "NUMBER" // 1343456, 1.23456
+	STRING       = "STRING" // "foobar"
+	COMMENT      = "#"      // # Comment
+	AT           = "@"      // @ At symbol
+	NULL         = "NULL"   // # null
+	CURRENT_ARGS = "..."    // # ... function args
 
 	// Operators
 	TILDE         = "~"


### PR DESCRIPTION
Functions can now be "named":

```js
f my_func(x) {
  return x**2
}
```

Earlier, you would have had to assign
the function to a variable:

```js
my_func = f(x) {
  return x**2
}
```

while right now function names are first-class
citizens. For example, the string representation
of a function will actualy include its name (to be
included in stacktraces as well):

```console
⧐  f test() {echo(1)}
f test() {echo(1)}
```