### PR TITLE
Ability to call a function with dynamic arguments: fn.call(args)

### DIFF
--- a/docs/types/function.md
+++ b/docs/types/function.md
@@ -93,6 +93,15 @@ f(x){}.str()
 # }
 ```
 
+### call(args)
+
+Calls a function with the given arguments:
+
+``` bash
+doubler = f(x) { x * 2 }
+doubler.call([10]) # 20
+```
+
 ## Next
 
 That's about it for this section!

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -976,6 +976,8 @@ c")`, []string{"a", "b", "c"}},
 		{`[[1,2,3], [2,3,4]].tsv("abc")`, "1a2a3\n2a3a4"},
 		{`[[1,2,3], [2,3,4]].tsv("")`, "the separator argument to the tsv() function needs to be a valid character, '' given"},
 		{`[{"c": 3, "b": "hello"}, {"b": 20, "c": 0}].tsv("\t", ["c", "b", "a"])`, "c\tb\ta\n3\thello\tnull\n0\t20\tnull"},
+		{`adder = f (a, b) { return a + b }; adder.call([5, 5])`, 10},
+		{`int.call(["12"])`, 12},
 	}
 	for _, tt := range tests {
 		evaluated := testEval(tt.input)

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -136,6 +136,11 @@ func getFns() map[string]*object.Builtin {
 			Types: []string{},
 			Fn:    typeFn,
 		},
+		// fn.call(args_array)
+		"call": &object.Builtin{
+			Types: []string{object.FUNCTION_OBJ, object.BUILTIN_OBJ},
+			Fn:    callFn,
+		},
 		// split(string:"hello")
 		"split": &object.Builtin{
 			Types: []string{object.STRING_OBJ},
@@ -832,6 +837,16 @@ func typeFn(tok token.Token, env *object.Environment, args ...object.Object) obj
 	}
 
 	return &object.String{Token: tok, Value: string(args[0].Type())}
+}
+
+// fn.call(args_array)
+func callFn(tok token.Token, env *object.Environment, args ...object.Object) object.Object {
+	err := validateArgs(tok, "call", args, 2, [][]string{{object.FUNCTION_OBJ, object.BUILTIN_OBJ}, {object.ARRAY_OBJ}})
+	if err != nil {
+		return err
+	}
+
+	return applyFunction(tok, args[0], env, args[1].(*object.Array).Elements)
 }
 
 // split(string:"hello world!", sep:" ")


### PR DESCRIPTION
`call` calls a function with the arguments passed:

``` bash
multiplier = f(x, y) { x * y }
multiplier.call([10, 2]) # 20
```