### PR TITLE
Allow embedded interpolation, closes #330

### DIFF
--- a/docs/types/string.md
+++ b/docs/types/string.md
@@ -102,6 +102,16 @@ simply need to escape them with a `\`:
 "\$non_existing_var" # "$non_existing_var"
 ```
 
+An alternative syntax (`${...}`) is available for special
+cases -- for example, when your string is embedded
+within another string:
+
+``` bash
+word = "word"
+echo("prefix$wordsuffix") # "prefix"
+echo("prefix${word}suffix") # "prefixwordsuffix"
+```
+
 ## Special characters embedded in strings
 
 Double and single quoted strings behave differently if the string contains

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -3,6 +3,8 @@ package util
 import (
 	"os"
 	"testing"
+
+	"github.com/abs-lang/abs/object"
 )
 
 func TestUnaliasPath(t *testing.T) {
@@ -73,6 +75,37 @@ func TestIsNumber(t *testing.T) {
 	for _, tt := range tests {
 		if tt.expected != IsNumber(tt.number) {
 			t.Fatalf("expected %v (%s)", tt.expected, tt.number)
+		}
+	}
+}
+
+func TestInterpolateStringVars(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"string", "string"},
+		{"string $string string", "string test string"},
+		{"string $string", "string test"},
+		{"$string", "test"},
+		{"${string}", "test"},
+		{"\\$string", "$string"},
+		{"\\${string}", "${string}"},
+		{"_$string", "_test"},
+		{"string$string\\string", "stringtest\\string"},
+		{"$string_", ""},
+		{"xy\\z", "xy\\z"},
+		{"${string}_", "test_"},
+		{"${string x", "${string x"},
+	}
+
+	env := object.NewEnvironment(os.Stdout, "")
+	env.Set("string", &object.String{Value: "test"})
+
+	for _, tt := range tests {
+		output := InterpolateStringVars(tt.input, env)
+		if tt.expected != output {
+			t.Fatalf("expected '%v', got '%v' (original: %s)", tt.expected, output, tt.input)
 		}
 	}
 }


### PR DESCRIPTION
Variables can now be interpolate with both `$var` and `${var}`,
allowing this:

```
x = 2
"1${x}3" # 123
```