### PR TITLE
number.clamp(min, max)

### DIFF
--- a/docs/types/number.md
+++ b/docs/types/number.md
@@ -102,6 +102,17 @@ Rounds the number up to the closest integer:
 10.3.ceil() # 11
 ```
 
+### clamp(min, max)
+
+Clamps the number between min and max:
+
+``` bash
+10.clamp(0, 100) # 10
+10.clamp(0, 5) # 5
+10.clamp(50, 100) # 50
+1.5.clamp(2.5, 3) # 2.5
+```
+
 ### floor()
 
 Rounds the number down to the closest integer:

--- a/evaluator/builtin_functions_test.go
+++ b/evaluator/builtin_functions_test.go
@@ -569,6 +569,25 @@ func TestBetween(t *testing.T) {
 	testBuiltinFunction(tests, t)
 }
 
+func TestClamp(t *testing.T) {
+	tests := []Tests{
+		{`2.clamp(0, 10)`, 2},
+		{`2.clamp(2, 10)`, 2},
+		{`2.clamp(3, 10)`, 3},
+		{`2.clamp(0, 3)`, 2},
+		{`2.clamp(2, 3)`, 2},
+		{`2.clamp(3, 3)`, "arguments to clamp(min, max) must satisfy min < max"},
+		{`2.clamp(3, 10)`, 3},
+		{`2.clamp(0, 1)`, 1},
+		{`2.clamp(0, 2)`, 2},
+		{`2.clamp(1.5, 2.5)`, 2},
+		{`2.clamp(2.1, 2.5)`, 2.1},
+		{`2.5.clamp(2.1, 2.3)`, 2.3},
+	}
+
+	testBuiltinFunction(tests, t)
+}
+
 func testBuiltinFunction(tests []Tests, t *testing.T) {
 	for _, tt := range tests {
 		evaluated := testEval(tt.input)

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -71,6 +71,11 @@ func getFns() map[string]*object.Builtin {
 			Types: []string{},
 			Fn:    cdFn,
 		},
+		// clamp(num, min, max)
+		"clamp": &object.Builtin{
+			Types: []string{object.NUMBER_OBJ},
+			Fn:    clampFn,
+		},
 		// echo(arg:"hello")
 		"echo": &object.Builtin{
 			Types: []string{},
@@ -616,6 +621,34 @@ func cdFn(tok token.Token, env *object.Environment, args ...object.Object) objec
 	// this will also test true/false for cd("path/to/somewhere") && `ls`
 	dir, _ := os.Getwd()
 	return &object.String{Token: tok, Value: dir, Ok: &object.Boolean{Token: tok, Value: true}}
+}
+
+// clamp(n, min, max)
+func clampFn(tok token.Token, env *object.Environment, args ...object.Object) object.Object {
+	err := validateArgs(tok, "clamp", args, 3, [][]string{{object.NUMBER_OBJ}, {object.NUMBER_OBJ}, {object.NUMBER_OBJ}})
+	if err != nil {
+		return err
+	}
+
+	n := args[0].(*object.Number)
+	min := args[1].(*object.Number)
+	max := args[2].(*object.Number)
+
+	if min.Value >= max.Value {
+		return newError(tok, "arguments to clamp(min, max) must satisfy min < max (%s < %s given)", min.Inspect(), max.Inspect())
+	}
+
+	val := n.Value
+
+	if min.Value > n.Value {
+		val = min.Value
+	}
+
+	if max.Value < n.Value {
+		val = max.Value
+	}
+
+	return &object.Number{Value: val}
 }
 
 // echo(arg:"hello")


### PR DESCRIPTION
Clamps the number between min and max:

``` bash
10.clamp(0, 100) # 10
10.clamp(0, 5) # 5
10.clamp(50, 100) # 50
1.5.clamp(2.5, 3) # 2.5
```