### PR TITLE
number.between(min, max)

### DIFF
--- a/docs/types/number.md
+++ b/docs/types/number.md
@@ -84,6 +84,16 @@ by default:
 10.333.round(1) # 10.3
 ```
 
+### between(min, max)
+
+Checks whether the number is between `min` and `max`:
+
+``` bash
+10.between(0, 100) # true
+10.between(10, 100) # true
+10.between(11, 100) # false
+```
+
 ### ceil()
 
 Rounds the number up to the closest integer:

--- a/evaluator/builtin_functions_test.go
+++ b/evaluator/builtin_functions_test.go
@@ -557,6 +557,18 @@ func TestChunk(t *testing.T) {
 	testBuiltinFunction(tests, t)
 }
 
+func TestBetween(t *testing.T) {
+	tests := []Tests{
+		{`1.between(0, 2)`, true},
+		{`1.between(0, 1.1)`, true},
+		{`1.between(0, 0.9)`, false},
+		{`1.between(1, 0)`, "arguments to between(min, max) must satisfy min < max (1 < 0 given)"},
+		{`1.between(1, 2)`, true},
+	}
+
+	testBuiltinFunction(tests, t)
+}
+
 func testBuiltinFunction(tests []Tests, t *testing.T) {
 	for _, tt := range tests {
 		evaluated := testEval(tt.input)

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -222,6 +222,11 @@ func getFns() map[string]*object.Builtin {
 			Types: []string{object.STRING_OBJ},
 			Fn:    anyFn,
 		},
+		// between(number, min, max)
+		"between": &object.Builtin{
+			Types: []string{object.NUMBER_OBJ},
+			Fn:    betweenFn,
+		},
 		// prefix("abc", "a")
 		"prefix": &object.Builtin{
 			Types: []string{object.STRING_OBJ},
@@ -1296,6 +1301,24 @@ func anyFn(tok token.Token, env *object.Environment, args ...object.Object) obje
 	}
 
 	return &object.Boolean{Token: tok, Value: strings.ContainsAny(args[0].(*object.String).Value, args[1].(*object.String).Value)}
+}
+
+// between(10, 0, 100)
+func betweenFn(tok token.Token, env *object.Environment, args ...object.Object) object.Object {
+	err := validateArgs(tok, "between", args, 3, [][]string{{object.NUMBER_OBJ}, {object.NUMBER_OBJ}, {object.NUMBER_OBJ}})
+	if err != nil {
+		return err
+	}
+
+	n := args[0].(*object.Number)
+	min := args[1].(*object.Number)
+	max := args[2].(*object.Number)
+
+	if min.Value >= max.Value {
+		return newError(tok, "arguments to between(min, max) must satisfy min < max (%s < %s given)", min.Inspect(), max.Inspect())
+	}
+
+	return &object.Boolean{Token: tok, Value: ((min.Value <= n.Value) && (n.Value <= max.Value))}
 }
 
 // prefix("abc", "a")


### PR DESCRIPTION
Checks whether the number is between `min` and `max`:

``` bash
10.between(0, 100) # true
10.between(10, 100) # true
10.between(11, 100) # false
```