### PR TITLE
shortand syntax for array.find(...)

### DIFF
--- a/docs/types/array.md
+++ b/docs/types/array.md
@@ -183,6 +183,13 @@ Returns the first element that returns `true` when applied to the function `f`:
 ["hello", 0, 1, 2].find(f(x){type(x) == "NUMBER"}) # 0
 ```
 
+A shorthand syntax supports passing a hash and comparing
+elements to the given hash:
+
+```bash
+[null, {"key": "val", "test": 123}].find({"key": "val"}) # {"key": "val", "test": 123}
+```
+
 ### len()
 
 Returns the length of the array:

--- a/docs/types/array.md
+++ b/docs/types/array.md
@@ -365,6 +365,17 @@ Returns an array with unique values:
 [1, 1, 1, 2].unique() # [1, 2]
 ```
 
+### intersect(array)
+
+Computes the intersection between 2 arrays:
+
+```bash
+[1, 2, 3].intersect([]) # []
+[1, 2, 3].intersect([3]) # [3]
+[1, 2, 3].intersect([3, 1]) # [1, 3]
+[1, 2, 3].intersect([1, 2, 3, 4]) # [1, 2, 3]
+```
+
 ## Next
 
 That's about it for this section!

--- a/docs/types/array.md
+++ b/docs/types/array.md
@@ -376,6 +376,18 @@ Computes the intersection between 2 arrays:
 [1, 2, 3].intersect([1, 2, 3, 4]) # [1, 2, 3]
 ```
 
+### diff(array)
+
+Computes the difference between 2 arrays
+(elements that are only on either of the 2):
+
+```bash
+[1, 2, 3].diff([]) # [1, 2, 3]
+[1, 2, 3].diff([3]) # [1, 2]
+[1, 2, 3].diff([3, 1]) # [2]
+[1, 2, 3].diff([1, 2, 3, 4]) # [4]
+```
+
 ## Next
 
 That's about it for this section!

--- a/evaluator/builtin_functions_test.go
+++ b/evaluator/builtin_functions_test.go
@@ -136,6 +136,11 @@ func TestFind(t *testing.T) {
 	tests := []Tests{
 		{`find([1,2,3,3], f(x) {x == 3})`, 3},
 		{`find([1,2], f(x) {x == "some"})`, nil},
+		{`find([{}, {}], f(x) {x.y == 1})`, nil},
+		{`x = find([{}, {"y": 1, "z": 10}, {}], f(x) {x.y == 1}); x.z`, 10},
+		{`x = find([{}, {"y": 1, "z": 10}, {}], {"y": 1}); x.z`, 10},
+		{`x = find([{}, {"y": {}, "z": 10}, {}], {"y": {}}); x.z`, 10},
+		{`find([{}, {"y": "1", "z": 10}, {}], {"y": 1})`, nil},
 	}
 
 	testBuiltinFunction(tests, t)

--- a/evaluator/builtin_functions_test.go
+++ b/evaluator/builtin_functions_test.go
@@ -623,6 +623,17 @@ func TestKebab(t *testing.T) {
 	testBuiltinFunction(tests, t)
 }
 
+func TestIntersect(t *testing.T) {
+	tests := []Tests{
+		{`[1,2,3].intersect([])`, []int{}},
+		{`[1,2,3].intersect([3])`, []int{3}},
+		{`[1,2,3].intersect([3, 1])`, []int{1, 3}},
+		{`[1,2,3].intersect([1,2,3,4])`, []int{1, 2, 3}},
+	}
+
+	testBuiltinFunction(tests, t)
+}
+
 func testBuiltinFunction(tests []Tests, t *testing.T) {
 	for _, tt := range tests {
 		evaluated := testEval(tt.input)

--- a/evaluator/builtin_functions_test.go
+++ b/evaluator/builtin_functions_test.go
@@ -634,6 +634,17 @@ func TestIntersect(t *testing.T) {
 	testBuiltinFunction(tests, t)
 }
 
+func TestDiff(t *testing.T) {
+	tests := []Tests{
+		{`[1,2,3].diff([])`, []int{1, 2, 3}},
+		{`[1,2,3].diff([3])`, []int{1, 2}},
+		{`[1,2,3].diff([3, 1])`, []int{2}},
+		{`[1,2,3].diff([1,2,3,4])`, []int{4}},
+	}
+
+	testBuiltinFunction(tests, t)
+}
+
 func testBuiltinFunction(tests []Tests, t *testing.T) {
 	for _, tt := range tests {
 		evaluated := testEval(tt.input)

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -198,6 +198,11 @@ func getFns() map[string]*object.Builtin {
 			Types: []string{object.ARRAY_OBJ},
 			Fn:    sortFn,
 		},
+		// intersect(array:[1, 2, 3], array:[1, 2, 3])
+		"intersect": &object.Builtin{
+			Types: []string{object.ARRAY_OBJ},
+			Fn:    intersectFn,
+		},
 		// map(array:[1, 2, 3], function:f(x) { x + 1 })
 		"map": &object.Builtin{
 			Types: []string{object.ARRAY_OBJ},
@@ -1170,6 +1175,33 @@ func sortFn(tok token.Token, env *object.Environment, args ...object.Object) obj
 	default:
 		return newError(tok, "cannot sort an array with given elements elements (%s)", arr.Inspect())
 	}
+}
+
+// intersect(array:[1, 2, 3], array:[1, 2, 3])
+func intersectFn(tok token.Token, env *object.Environment, args ...object.Object) object.Object {
+	err := validateArgs(tok, "intersect", args, 2, [][]string{{object.ARRAY_OBJ}, {object.ARRAY_OBJ}})
+	if err != nil {
+		return err
+	}
+
+	left := args[0].(*object.Array).Elements
+	right := args[1].(*object.Array).Elements
+	found := map[string]object.Object{}
+	intersection := []object.Object{}
+
+	for _, o := range right {
+		found[string(o.Type())+"__"+o.Inspect()] = o
+	}
+
+	for _, o := range left {
+		element, ok := found[string(o.Type())+"__"+o.Inspect()]
+
+		if ok {
+			intersection = append(intersection, element)
+		}
+	}
+
+	return &object.Array{Elements: intersection}
 }
 
 // map(array:[1, 2, 3], function:f(x) { x + 1 })

--- a/object/object.go
+++ b/object/object.go
@@ -57,6 +57,13 @@ type Object interface {
 	Json() string
 }
 
+// Equal compares 2 objects
+// and makes sure they represent
+// the same value.
+func Equal(obj1 Object, obj2 Object) bool {
+	return obj1.Type() == obj2.Type() && obj1.Inspect() == obj2.Inspect()
+}
+
 type Iterable interface {
 	Next() (Object, Object)
 	Reset()


### PR DESCRIPTION
A shorthand syntax supports passing a hash and comparing
elements to the given hash:

```bash
[null, {"key": "val", "test": 123}].find({"key": "val"}) # {"key": "val", "test": 123}
```