### PR TITLE
symmetric vs asymmetric difference

### DIFF
--- a/docs/types/array.md
+++ b/docs/types/array.md
@@ -378,8 +378,22 @@ Computes the intersection between 2 arrays:
 
 ### diff(array)
 
-Computes the difference between 2 arrays
-(elements that are only on either of the 2):
+Computes the difference between 2 arrays,
+returning elements that are only on the first array:
+
+```bash
+[1, 2, 3].diff([]) # [1, 2, 3]
+[1, 2, 3].diff([3]) # [1, 2]
+[1, 2, 3].diff([3, 1]) # [2]
+[1, 2, 3].diff([1, 2, 3, 4]) # []
+```
+
+For symmetric difference see [diff_symmetric(...)](#diff_symmetricarray)
+
+### diff_symmetric(array)
+
+Computes the [symmetric difference](https://en.wikipedia.org/wiki/Symmetric_difference)
+between 2 arrays (elements that are only on either of the 2):
 
 ```bash
 [1, 2, 3].diff([]) # [1, 2, 3]

--- a/evaluator/builtin_functions_test.go
+++ b/evaluator/builtin_functions_test.go
@@ -639,7 +639,18 @@ func TestDiff(t *testing.T) {
 		{`[1,2,3].diff([])`, []int{1, 2, 3}},
 		{`[1,2,3].diff([3])`, []int{1, 2}},
 		{`[1,2,3].diff([3, 1])`, []int{2}},
-		{`[1,2,3].diff([1,2,3,4])`, []int{4}},
+		{`[1,2,3].diff([1,2,3,4])`, []int{}},
+	}
+
+	testBuiltinFunction(tests, t)
+}
+
+func TestDiffSymmetric(t *testing.T) {
+	tests := []Tests{
+		{`[1,2,3].diff_symmetric([])`, []int{1, 2, 3}},
+		{`[1,2,3].diff_symmetric([3])`, []int{1, 2}},
+		{`[1,2,3].diff_symmetric([3, 1])`, []int{2}},
+		{`[1,2,3].diff_symmetric([1,2,3,4])`, []int{4}},
 	}
 
 	testBuiltinFunction(tests, t)


### PR DESCRIPTION
Computes the difference between 2 arrays,
returning elements that are only on the first array:

```bash
[1, 2, 3].diff([]) # [1, 2, 3]
[1, 2, 3].diff([3]) # [1, 2]
[1, 2, 3].diff([3, 1]) # [2]
[1, 2, 3].diff([1, 2, 3, 4]) # []
```

For symmetric difference see [diff_symmetric(...)](#diff_symmetricarray)

Computes the [symmetric difference](https://en.wikipedia.org/wiki/Symmetric_difference)
between 2 arrays (elements that are only on either of the 2):

```bash
[1, 2, 3].diff([]) # [1, 2, 3]
[1, 2, 3].diff([3]) # [1, 2]
[1, 2, 3].diff([3, 1]) # [2]
[1, 2, 3].diff([1, 2, 3, 4]) # [4]
```