### PR TITLE
array.union(other_array)

### DIFF
--- a/docs/types/array.md
+++ b/docs/types/array.md
@@ -402,6 +402,18 @@ between 2 arrays (elements that are only on either of the 2):
 [1, 2, 3].diff([1, 2, 3, 4]) # [4]
 ```
 
+### union(array)
+
+Computes the [union](https://en.wikipedia.org/wiki/Union_(set_theory))
+between 2 arrays:
+
+```bash
+[1, 2, 3].union([1, 2, 3, 4]) # [1, 2, 3, 4]
+[1, 2, 3].union([3]) # [1, 2, 3]
+[].union([3, 1]) # [3, 1]
+[1, 2].union([3, 4]) # [1, 2, 3, 4]
+```
+
 ## Next
 
 That's about it for this section!

--- a/evaluator/builtin_functions_test.go
+++ b/evaluator/builtin_functions_test.go
@@ -656,6 +656,17 @@ func TestDiffSymmetric(t *testing.T) {
 	testBuiltinFunction(tests, t)
 }
 
+func TestUnion(t *testing.T) {
+	tests := []Tests{
+		{`[1, 2, 3].union([1, 2, 3, 4])`, []int{1, 2, 3, 4}},
+		{`[1, 2, 3].union([3])`, []int{1, 2, 3}},
+		{`[].union([3, 1])`, []int{3, 1}},
+		{`[1, 2].union([3, 4])`, []int{1, 2, 3, 4}},
+	}
+
+	testBuiltinFunction(tests, t)
+}
+
 func testBuiltinFunction(tests []Tests, t *testing.T) {
 	for _, tt := range tests {
 		evaluated := testEval(tt.input)

--- a/object/object.go
+++ b/object/object.go
@@ -57,11 +57,23 @@ type Object interface {
 	Json() string
 }
 
+// GenerateEqualityString is used to compare
+// 2 objects, for example from different arrays.
+//
+// This function will generate a string that can
+// be used to compare the 2, including their type
+// and their string representation. Only using their
+// string representation wouldn't work as "1" would
+// be the same as 1.
+func GenerateEqualityString(o Object) string {
+	return fmt.Sprintf("%s:%s", o.Type(), o.Inspect())
+}
+
 // Equal compares 2 objects
 // and makes sure they represent
 // the same value.
 func Equal(obj1 Object, obj2 Object) bool {
-	return obj1.Type() == obj2.Type() && obj1.Inspect() == obj2.Inspect()
+	return GenerateEqualityString(obj1) == GenerateEqualityString(obj2)
 }
 
 type Iterable interface {

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -20,3 +20,25 @@ func TestStringHashKey(t *testing.T) {
 		t.Errorf("strings with different content have same hash keys")
 	}
 }
+
+func TestGenerateEqualityString(t *testing.T) {
+	tests := []struct {
+		input    Object
+		expected string
+	}{
+		{&String{Value: "a"}, "STRING:a"},
+		{&Array{Elements: []Object{FALSE}}, "ARRAY:[false]"},
+		{&Array{Elements: []Object{&Number{Value: 1}}}, "ARRAY:[1]"},
+		{&Array{Elements: []Object{&String{Value: "1"}}}, "ARRAY:[\"1\"]"},
+		{&Hash{}, "HASH:{}"},
+		{&Hash{Pairs: map[HashKey]HashPair{}}, "HASH:{}"},
+		{&Hash{Pairs: map[HashKey]HashPair{HashKey{Value: "x", Type: STRING_OBJ}: HashPair{&String{Value: "x"}, &String{Value: "x"}}}}, "HASH:{\"x\": \"x\"}"},
+	}
+
+	for _, tt := range tests {
+		output := GenerateEqualityString(tt.input)
+		if tt.expected != output {
+			t.Fatalf("expected '%v', got '%v' (original: %s)", tt.expected, output, tt.input.Inspect())
+		}
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -155,3 +155,19 @@ func appendIndexFile(path string) string {
 
 	return path
 }
+
+// Mapify converts a list of objects to a map.
+// This is useful when you want to test whether
+// elements of a list are present in another list:
+// You can mapify the first one and check whether
+// elements of the second one would occupy the same
+// key in the map.
+func Mapify(list []object.Object) map[string]object.Object {
+	m := make(map[string]object.Object)
+
+	for _, v := range list {
+		m[object.GenerateEqualityString(v)] = v
+	}
+
+	return m
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -109,3 +109,24 @@ func TestInterpolateStringVars(t *testing.T) {
 		}
 	}
 }
+
+func TestMapify(t *testing.T) {
+	elements := []object.Object{}
+	first := &object.String{Value: "x"}
+	second := &object.Number{Value: 10}
+	elements = append(elements, first, second)
+
+	m := Mapify(elements)
+
+	if len(m) != 2 {
+		t.Fatalf("expected len '%d', got '%d'", 2, len(m))
+	}
+
+	if m["STRING:x"] != first {
+		t.Fatalf("string element not found")
+	}
+
+	if m["NUMBER:10"] != second {
+		t.Fatalf("number element not found")
+	}
+}


### PR DESCRIPTION
Computes the [union](https://en.wikipedia.org/wiki/Union_(set_theory))
between 2 arrays:

```bash
[1, 2, 3].union([1, 2, 3, 4]) # [1, 2, 3, 4]
[1, 2, 3].union([3]) # [1, 2, 3]
[].union([3, 1]) # [3, 1]
[1, 2].union([3, 4]) # [1, 2, 3, 4]
```