### PR TITLE
array.reduce(fn, acc)

### DIFF
--- a/docs/types/array.md
+++ b/docs/types/array.md
@@ -459,6 +459,21 @@ Reduces the array to a value by iterating through its elements and applying `fn`
 [1, 2, 3, 4].reduce(f(value, element) { return value + element }, 10) # 20
 ```
 
+
+### partition(fn)
+
+Partitions the array by applying `fn` to all of its elements
+and using the result of the function invocation as the key to partition by:
+
+```py
+f odd(n) {
+  return !!(n % 2)
+}
+
+[0, 1, 2, 3, 4, 5].partition(odd) # [[0, 2, 4], [1, 3, 5]]
+[1, "1", {}].partition(str) # [[1, "1"], [{}]]
+```
+
 ## Next
 
 That's about it for this section!

--- a/docs/types/array.md
+++ b/docs/types/array.md
@@ -450,6 +450,15 @@ Finds the lowest number in an array:
 [0, 5, -10, 100].min() # -10
 ```
 
+### reduce(fn, accumulator)
+
+Reduces the array to a value by iterating through its elements and applying `fn` to them:
+
+```py
+[1, 2, 3, 4].reduce(f(value, element) { return value + element }, 0) # 10
+[1, 2, 3, 4].reduce(f(value, element) { return value + element }, 10) # 20
+```
+
 ## Next
 
 That's about it for this section!

--- a/evaluator/builtin_functions_test.go
+++ b/evaluator/builtin_functions_test.go
@@ -715,6 +715,16 @@ func TestMin(t *testing.T) {
 	testBuiltinFunction(tests, t)
 }
 
+func TestReduce(t *testing.T) {
+	tests := []Tests{
+		{`[1, 2, 3, 4].reduce(f(value, element) { return value + element }, 0)`, 10},
+		{`[1, 2, 3, 4].reduce(f(value, element) { return value + element }, 10)`, 20},
+		{`[1, 2, 3, 4].reduce(f(value, element) { return value + element })`, "wrong number of arguments to reduce(...)"},
+	}
+
+	testBuiltinFunction(tests, t)
+}
+
 func testBuiltinFunction(tests []Tests, t *testing.T) {
 	for _, tt := range tests {
 		evaluated := testEval(tt.input)

--- a/evaluator/builtin_functions_test.go
+++ b/evaluator/builtin_functions_test.go
@@ -725,6 +725,17 @@ func TestReduce(t *testing.T) {
 	testBuiltinFunction(tests, t)
 }
 
+func TestPartition(t *testing.T) {
+	tests := []Tests{
+		{`[1, 1, 2, 2, 0].partition(f(x) { return x == 0 })[0]`, []int{1, 1, 2, 2}},
+		{`[1, 1, 2, 2, 0].partition(f(x) { return x == 0 })[1]`, []int{0}},
+		{`[1, "1"].partition(str)[0][0]`, 1},
+		{`[1, "1"].partition(str)[0][1]`, "1"},
+	}
+
+	testBuiltinFunction(tests, t)
+}
+
 func testBuiltinFunction(tests []Tests, t *testing.T) {
 	for _, tt := range tests {
 		evaluated := testEval(tt.input)

--- a/object/object.go
+++ b/object/object.go
@@ -27,6 +27,8 @@ const (
 
 	RETURN_VALUE_OBJ = "RETURN_VALUE"
 
+	// ANY_OBJ represents any ABS type
+	ANY_OBJ      = "ANY"
 	FUNCTION_OBJ = "FUNCTION"
 	BUILTIN_OBJ  = "BUILTIN"
 


### PR DESCRIPTION
Reduces the array to a value by iterating through its elements and applying `fn` to them:

```py
[1, 2, 3, 4].reduce(f(value, element) { return value + element }, 0) # 10
[1, 2, 3, 4].reduce(f(value, element) { return value + element }, 10) # 20
```