### PR TITLE
Fixed mixing property and index expression assignment, closes #355

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -639,6 +639,7 @@ func TestAssignStatements(t *testing.T) {
 		expected interface{}
 	}{
 		{"a = 5; a;", 5},
+		{`a = {"b": {"c": {"d": ""}}}; a.b['c'].e = 123; a.b.c.d = 123; a.b.c.d`, 123},
 		{"a = 5 * 5; a;", 25},
 		{"a = 5; b = a; b;", 5},
 		{"a = 5; b = a; c = a + b + 5; c;", 15},

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -530,6 +530,7 @@ func (p *Parser) parseDottedExpression(object ast.Expression) ast.Expression {
 		exp := &ast.PropertyExpression{Token: t, Object: object}
 		exp.Property = p.parseIdentifier()
 		p.prevPropertyExpression = exp
+		p.prevIndexExpression = nil
 		return exp
 	}
 }
@@ -950,6 +951,7 @@ func (p *Parser) parseIndexExpression(left ast.Expression) ast.Expression {
 	}
 	// support assignment to index expression: a[0] = 1
 	p.prevIndexExpression = exp
+	p.prevPropertyExpression = nil
 
 	return exp
 }


### PR DESCRIPTION
The way we assign to properties or indexes is pretty
awkward as we temporarely store in the parser the
last parsed expression -- with the caveat that we store
2 of these values, one for properties and one for indexes.
When either of them gets set, we need to "consume" the other one.

This probably needs to be rethought at some point but for
the time being this is a simple fix.