### PR TITLE
Default values for function parameters, closes #368

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -171,6 +171,25 @@ func (i *Identifier) expressionNode()      {}
 func (i *Identifier) TokenLiteral() string { return i.Token.Literal }
 func (i *Identifier) String() string       { return i.Value }
 
+// Parameter is a function parameter
+// fn(x, y = 2)
+type Parameter struct {
+	*Identifier
+	Default Expression
+}
+
+func (p *Parameter) expressionNode()      {}
+func (p *Parameter) TokenLiteral() string { return p.Token.Literal }
+func (p *Parameter) String() string {
+	s := p.Value
+
+	if p.Default != nil {
+		s += " = " + p.Default.String()
+	}
+
+	return s
+}
+
 type Boolean struct {
 	Token token.Token
 	Value bool
@@ -411,7 +430,7 @@ func (ce *CommandExpression) String() string {
 type FunctionLiteral struct {
 	Token      token.Token // The 'fn' token
 	Name       string      // identifier for this function
-	Parameters []*Identifier
+	Parameters []*Parameter
 	Body       *BlockStatement
 }
 

--- a/docs/types/function.md
+++ b/docs/types/function.md
@@ -28,17 +28,7 @@ favors `f` for 2 main reasons:
 * brevity
 * resembles the standard mathematical notation everyone is used to (*x ↦ f(x)*)
 
-Functions must be called with the right number of arguments:
-
-``` bash
-fn = f(x) { x }
-fn()
-# ERROR: Wrong number of arguments passed to f(x) {
-# x
-# }. Want [x], got []
-```
-
-They can be passed as arguments to other functions:
+Functions can be passed as arguments to other functions:
 
 ``` bash
 [1, 2, 3].map(f(x){ x + 1}) # [2, 3, 4]
@@ -87,11 +77,11 @@ You can create named functions by specifying an identifier
 after the `f` keyword:
 
 ``` bash
-f greeter(name) {
+f greet(name) {
     echo("Hello $name!")
 }
 
-greeter(`whoami`) # "Hello root!"
+greet(`whoami`) # "Hello root!"
 ```
 
 As an alternative, you can manually assign
@@ -99,14 +89,59 @@ a function declaration to a variable, though
 this is not the recommended approach:
 
 ``` bash
-greeter = f (name) {
+greet = f (name) {
     echo("Hello $name!")
 }
 
-greeter(`whoami`) # "Hello root!"
+greet(`whoami`) # "Hello root!"
 ```
 
 Named functions are the basis of [decorators](/types/decorators).
+
+## Optional parameters
+
+Functions must be called with the right number of arguments:
+
+``` bash
+f greet(name, greeting) {
+    echo("$greeting $name!")
+}
+greet("user")
+# ERROR: argument greeting to function f greet(name, greeting) {echo($greeting $name!)} is missing, and doesn't have a default value
+# 	[1:1]	greet("user")
+```
+
+but note that you could make a parameter optional by specifying its
+default value:
+
+``` bash
+f greet(name, greeting = "hello") {
+    echo("$greeting $name!")
+}
+greet("user") # hello user!
+greet("user", "hola") # hola user!
+```
+
+A default value can be any expression (doesn't have to be a literal):
+
+```bash
+f test(x = 1){x}; test() # 1
+f test(x = "test".split("")){x}; test() # ["t", "e", "s", "t"]
+f test(x = {}){x}; test() # {}
+y = 100; f test(x = y){x}; test() # 100
+x = 100; f test(x = x){x}; test() # 100
+x = 100; f test(x = x){x}; test(1) # 1
+```
+
+Note that mandatory arguments always need to be declared
+before optional ones:
+
+``` bash
+f(x = null, y){}
+# parser errors:
+# 	found mandatory parameter after optional one
+# 	[1:13]	f(x = null, y){}
+```
 
 ## Accessing function arguments
 
@@ -168,6 +203,15 @@ echo_wrapper("hello %s %s", "sir") # "hello sir root"
 
 ## Supported functions
 
+### call(args)
+
+Calls a function with the given arguments:
+
+``` bash
+doubler = f(x) { x * 2 }
+doubler.call([10]) # 20
+```
+
 ### str()
 
 Returns the string representation of the function:
@@ -177,15 +221,6 @@ f(x){}.str()
 # f(x) {
 #
 # }
-```
-
-### call(args)
-
-Calls a function with the given arguments:
-
-``` bash
-doubler = f(x) { x * 2 }
-doubler.call([10]) # 20
 ```
 
 ## Next

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -1217,12 +1217,21 @@ func extendFunctionEnv(
 ) (*object.Environment, *object.Error) {
 	env := object.NewEnclosedEnvironment(fn.Env, args)
 
-	if len(args) < len(fn.Parameters) {
-		return nil, newError(fn.Token, "Wrong number of arguments passed to %s. Want %s, got %s", fn.Inspect(), fn.Parameters, args)
-	}
-
 	for paramIdx, param := range fn.Parameters {
-		env.Set(param.Value, args[paramIdx])
+		argumentPassed := len(args) > paramIdx
+
+		if !argumentPassed && param.Default == nil {
+			return nil, newError(fn.Token, "argument %s to function %s is missing, and doesn't have a default value", param.Value, fn.Inspect())
+		}
+
+		var arg object.Object
+		if argumentPassed {
+			arg = args[paramIdx]
+		} else {
+			arg = Eval(param.Default, env)
+		}
+
+		env.Set(param.Value, arg)
 	}
 
 	return env, nil

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -731,7 +731,12 @@ func TestFunctionApplication(t *testing.T) {
 		{"add = f(x, y) { x + y; }; add(5, 5);", 10},
 		{"add = f(x, y) { x + y; }; add(5 + 5, add(5, 5));", 20},
 		{"f(x) { x; }(5)", 5},
-		{"f(x) { x; }()", "Wrong number of arguments passed to f(x) {x}. Want [x], got []"},
+		{"f(x) { x; }()", "argument x to function f(x) {x} is missing, and doesn't have a default value"},
+		{"f(x = 2) { x; }()", 2},
+		{"f(x, y = 2) { x + y; }()", "argument x to function f(x, y = 2) {(x + y)} is missing, and doesn't have a default value"},
+		{"f test(x, y = 2) { x + y; }()", "argument x to function f test(x, y = 2) {(x + y)} is missing, and doesn't have a default value"},
+		{"f(x, y = 2) { x + y; }(1)", 3},
+		{"f(x, y = 2) { x + y; }(1, 1)", 2},
 	}
 
 	for _, tt := range tests {

--- a/object/object.go
+++ b/object/object.go
@@ -152,7 +152,7 @@ type ContinueError struct {
 type Function struct {
 	Token      token.Token
 	Name       string
-	Parameters []*ast.Identifier
+	Parameters []*ast.Parameter
 	Body       *ast.BlockStatement
 	Env        *Environment
 	Node       *ast.FunctionLiteral


### PR DESCRIPTION
This PR adds the ability to specify default values for function
arguments.

Optional parameters need to come right after mandatory ones:

```
⧐  f test(x = 1, y){}
 parser errors:
	found mandatory parameter after optional one
	[1:15]	f test(x = 1, y){}
```

and they can use any kind of expression:

```
⧐  f test(x = 1){ x }; test()
1
⧐  f test(x = []){ x }; test()
[]
⧐  f test(x = {}){ x }; test()
{}
⧐  f test(x = 1..10){ x }; test()
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
```

If a mandatory argument is not passed, ABS will now give you a more
detailed message:

```
⧐  f test(x){ x }; test()
ERROR: argument x to function f test(x) {x} is missing, and doesn't have a default value
	[1:1]	f test(x){ x }; test()
```