### PR TITLE
Check for newer release on GitHub

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/abs-lang/abs/install"
 	"github.com/abs-lang/abs/repl"
+	"github.com/abs-lang/abs/util"
 )
 
 // Version of the ABS interpreter
@@ -17,6 +18,15 @@ func main() {
 	if len(args) == 2 && args[1] == "--version" {
 		fmt.Println(Version)
 		return
+	}
+
+	if len(args) == 2 && args[1] == "--check-update" {
+		if newver, update := util.UpdateAvailable(Version); update {
+			fmt.Printf("Update available: %s (you have %s)\n", newver, Version)
+			os.Exit(1)
+		} else {
+			return
+		}
 	}
 
 	if len(args) == 3 && args[1] == "get" {

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -1,9 +1,11 @@
 package repl
 
 import (
+	"crypto/rand"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/big"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -228,6 +230,13 @@ func BeginRepl(args []string, version string) {
 			panic(err)
 		}
 		fmt.Printf("Hello %s, welcome to the ABS (%s) programming language!\n", user.Username, version)
+		// check for new version about 10% of the time,
+		// to avoid too many hangups
+		if r, e := rand.Int(rand.Reader, big.NewInt(100)); e == nil && r.Int64() < 10 {
+			if newver, update := util.UpdateAvailable(version); update {
+				fmt.Printf("*** Update available: %s ***\n", newver)
+			}
+		}
 		fmt.Printf("Type 'quit' when you're done, 'help' if you get lost!\n")
 		Start(os.Stdin, os.Stdout)
 	} else {

--- a/util/check_update.go
+++ b/util/check_update.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+const verUrl = "https://raw.githubusercontent.com/abs-lang/abs/master/VERSION"
+
+// Returns latest version, plus "new version available?" bool
+func UpdateAvailable(version string) (string, bool) {
+	resp, err := http.Get(verUrl)
+	if err != nil {
+		return version, false
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return version, false
+	}
+
+	latest := strings.TrimSpace(string(body))
+	if version != latest {
+		return latest, true
+	}
+
+	return version, false
+}

--- a/util/check_update_test.go
+++ b/util/check_update_test.go
@@ -1,0 +1,12 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestUpdateAvailable(t *testing.T) {
+	_, outdated := UpdateAvailable("1.0")
+	if !outdated {
+		t.Fatalf("expected 1.0 to be outdated")
+	}
+}


### PR DESCRIPTION
Added a command-line flag (--check-update) for scripted use,
and prompts in the welcome message for the REPL.

Uses https://github.com/tcnksm/go-latest to do the heavy lifting.

Closes #334.