### PR TITLE
Don't add comments to AST

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -221,6 +221,10 @@ func (p *Parser) ParseProgram() *ast.Program {
 }
 
 func (p *Parser) parseStatement() ast.Statement {
+	if p.curToken.Type == token.COMMENT {
+		return nil
+	}
+
 	if p.curToken.Type == token.RETURN {
 		return p.parseReturnStatement()
 	}


### PR DESCRIPTION
It just confuses the REPL into printing nothing, even when it should.

Closes #388.