### PR TITLE
Added a negative membership operator, closes #411

### DIFF
--- a/docs/syntax/operators.md
+++ b/docs/syntax/operators.md
@@ -112,6 +112,20 @@ Membership test operator (find whether a needle is in the haystack):
 "y" in {"x": 1} # false
 ```
 
+## !in
+
+Negative membership test operator (find whether a needle isnot in the haystack):
+
+``` bash
+1 !in [1, 2, 3] # false
+9 !in [1, 2, 3] # true
+9 !in 9 # unknown operator: NUMBER in NUMBER
+"str" !in "string" # false
+"xyz" !in "string" # true
+"x" !in {"x": 1} # false
+"y" !in {"x": 1} # true
+```
+
 ## **
 
 Mathematical exponentiation:

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -564,6 +564,8 @@ func evalInfixExpression(
 		return evalHashInfixExpression(tok, operator, left, right)
 	case operator == "in":
 		return evalInExpression(tok, left, right)
+	case operator == "!in":
+		return evalNotInExpression(tok, left, right)
 	case operator == "==":
 		return nativeBoolToBooleanObject(left == right)
 	case operator == "!=":
@@ -705,6 +707,10 @@ func evalStringInfixExpression(
 		return evalInExpression(tok, left, right)
 	}
 
+	if operator == "!in" {
+		return evalNotInExpression(tok, left, right).(*object.Boolean)
+	}
+
 	if operator == ">" {
 		err := writeFile(rightVal, leftVal)
 
@@ -821,6 +827,12 @@ func evalInExpression(tok token.Token, left, right object.Object) object.Object 
 	}
 
 	return &object.Boolean{Token: tok, Value: found}
+}
+
+func evalNotInExpression(tok token.Token, left, right object.Object) object.Object {
+	obj := evalInExpression(tok, left, right).(*object.Boolean)
+	obj.Value = !obj.Value
+	return obj
 }
 
 func evalIfExpression(

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -1055,6 +1055,10 @@ func TestInExpressions(t *testing.T) {
 		{`"x" in {"x": 0}`, true},
 		{`"y" in {"x": 0}`, false},
 		{`"y" in 12`, "'in' operator not supported on NUMBER"},
+		{`1 !in [1]`, false},
+		{`1 !in []`, true},
+		{`"x" !in ""`, true},
+		{`"x" !in "xyz"`, false},
 	}
 
 	for _, tt := range tests {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -133,6 +133,11 @@ func (l *Lexer) NextToken() token.Token {
 			l.readChar()
 			literal := string(ch) + string(l.ch)
 			tok.Literal = literal
+		} else if l.peekChars(3) == "in " {
+			tok = l.newToken(token.NOT_IN)
+			l.readChar()
+			l.readChar()
+			tok.Literal = "!in"
 		} else {
 			tok = l.newToken(token.BANG)
 		}
@@ -368,6 +373,13 @@ func (l *Lexer) readIdentifier() string {
 		l.readChar()
 	}
 	return string(l.input[position:l.position])
+}
+
+func (l *Lexer) peekChars(amount int) string {
+	if l.readPosition+amount >= len(l.input) {
+		return ""
+	}
+	return string(l.input[l.readPosition : l.readPosition+amount])
 }
 
 // List of character that can appear in a "number"

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -116,6 +116,9 @@ f hello(x, y) {
 @decorator
 @decorator()
 ...
+1 !in []
+!in_variable_named_in
+!i
 `
 
 	tests := []struct {
@@ -402,6 +405,14 @@ f hello(x, y) {
 		{token.LPAREN, "("},
 		{token.RPAREN, ")"},
 		{token.CURRENT_ARGS, "..."},
+		{token.NUMBER, "1"},
+		{token.NOT_IN, "!in"},
+		{token.LBRACKET, "["},
+		{token.RBRACKET, "]"},
+		{token.BANG, "!"},
+		{token.IDENT, "in_variable_named_in"},
+		{token.BANG, "!"},
+		{token.IDENT, "i"},
 		{token.EOF, ""},
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -38,6 +38,7 @@ var precedences = map[token.TokenType]int{
 	token.NOT_EQ:        EQUALS,
 	token.TILDE:         EQUALS,
 	token.IN:            EQUALS,
+	token.NOT_IN:        EQUALS,
 	token.COMMA:         EQUALS,
 	token.LT:            LESSGREATER,
 	token.LT_EQ:         LESSGREATER,
@@ -133,6 +134,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.NOT_EQ, p.parseInfixExpression)
 	p.registerInfix(token.TILDE, p.parseInfixExpression)
 	p.registerInfix(token.IN, p.parseInfixExpression)
+	p.registerInfix(token.NOT_IN, p.parseInfixExpression)
 	p.registerInfix(token.LT, p.parseInfixExpression)
 	p.registerInfix(token.LT_EQ, p.parseInfixExpression)
 	p.registerInfix(token.GT, p.parseInfixExpression)

--- a/token/token.go
+++ b/token/token.go
@@ -80,6 +80,7 @@ const (
 	WHILE    = "WHILE"
 	FOR      = "FOR"
 	IN       = "IN"
+	NOT_IN   = "NOT_IN"
 	BREAK    = "BREAK"
 	CONTINUE = "CONTINUE"
 )


### PR DESCRIPTION
You could previously test membership with `x in [x,y,z]`.
To negate that expression, you had to `!(x in [x,y,z])`.

Now you can use `!in`: `x !in [x,y,z]`.