### PR TITLE
Imported modules should be cached / a singleton, closes #427

### DIFF
--- a/evaluator/builtin_functions_test.go
+++ b/evaluator/builtin_functions_test.go
@@ -324,6 +324,7 @@ func TestSource(t *testing.T) {
 	tests := []Tests{
 		{`"a = 2; return 10" >> "test-ignore-source-vs-require.abs"; a = 1; x = source("test-ignore-source-vs-require.abs"); a`, 2},
 		{`"a = 2; return 10" >> "test-ignore-source-vs-require.abs"; a = 1; x = source("test-ignore-source-vs-require.abs"); x`, 10},
+		{`"a = 10" >> "test-ignore-source-is-not-cached.abs"; a = 1; source("test-ignore-source-is-not-cached.abs"); a = 1; source("test-ignore-source-is-not-cached.abs"); a`, 10},
 	}
 
 	testBuiltinFunction(tests, t)
@@ -331,8 +332,10 @@ func TestSource(t *testing.T) {
 
 func TestRequire(t *testing.T) {
 	tests := []Tests{
-		{`"a = 2; return 10" >> "test-ignore-source-vs-require.abs"; a = 1; x = require("test-ignore-source-vs-require.abs"); a`, 1},
-		{`"a = 2; return 10" >> "test-ignore-source-vs-require.abs"; a = 1; x = require("test-ignore-source-vs-require.abs"); x`, 10},
+		{`"a = 2; return 10" >> "test-ignore-source-vs-require.1.abs"; a = 1; x = require("test-ignore-source-vs-require.1.abs"); a`, 1},
+		{`"a = 2; return 10" >> "test-ignore-source-vs-require.2.abs"; a = 1; x = require("test-ignore-source-vs-require.2.abs"); x`, 10},
+		{`require('@runtime').name = "xxx"; require('@runtime').name`, "xxx"},
+		{`'return {"test": 11}' >> "test-ignore-require-is-cached.3.abs"; require('test-ignore-require-is-cached.3.abs').test = 0; require('test-ignore-require-is-cached.3.abs').test`, 0},
 	}
 
 	testBuiltinFunction(tests, t)

--- a/evaluator/stdlib_test.go
+++ b/evaluator/stdlib_test.go
@@ -14,7 +14,8 @@ type tests struct {
 func TestRuntime(t *testing.T) {
 	tests := []tests{
 		{`require('@runtime').version`, "test_version"},
-		{`require('@runtime').name`, "abs"},
+		{`"version" in require('@runtime').keys()`, true},
+		{`"name" in require('@runtime').keys()`, true},
 	}
 
 	testStdLib(tests, t)


### PR DESCRIPTION
With this change, a module that's been imported is now cached.
This means that every time you call `require('module')` you will
receive back the same evaluated result, meaning changes you make
on that result will be persisted. This only applies to `require`
and not `source`, as `source` is intended to be used in order to
always evaluate a block of fresh code in the current environment.

Before:

```
$ require('@runtime').name = "xxx"
$ require('@runtime').name
abs
```

After:

```
$ require('@runtime').name = "xxx"
$ require('@runtime').name
xxx
```