### PR TITLE
Added the ability to specify your own shell, closes #418

### DIFF
--- a/docs/src/docs/syntax/system-commands.md
+++ b/docs/src/docs/syntax/system-commands.md
@@ -117,6 +117,20 @@ simply need to escape them with a `\`:
 `echo \$PWD` # "/go/src/github.com/abs-lang/abs"
 ```
 
+## Using a different shell
+
+By default, ABS uses `bash -c` to execute commands; on Windows
+it instead uses `cmd.exe /C`.
+
+You can specify which shell to use by setting the environment
+variable `ABS_COMMAND_EXECUTOR`:
+
+```sh
+`echo \$0` # bash
+env("ABS_COMMAND_EXECUTOR", "sh -c")
+`echo \$0` # sh
+```
+
 ## Alternative \$() syntax
 
 Even though the use of backticks is the standard recommended
@@ -182,11 +196,3 @@ if filename.prefix('~/') || filename.prefix(homedir) {
 # execute the command with live stdIO
 exec("$sudo $cmd $filename")
 ```
-
-## Limitations
-
-Note that the implementation of system commands
-requires the `bash` executable to [be available on the system](https://github.com/abs-lang/abs/blob/5b5b0abf3115a5dd4dfe8485501f8765985ad0db/evaluator/evaluator.go#L696-L722).
-On Windows, commands are executed through [cmd.exe](https://github.com/abs-lang/abs/blob/ee793641be09ad8572c3e913fef8468f69b0c0a2/evaluator/evaluator.go#L1101-L1103).
-Future work will make it possible to select which shell to use,
-as well as bypassing the shell altogether (see [#73](https://github.com/abs-lang/abs/issues/73)).

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -31,6 +31,15 @@ var lex *lexer.Lexer
 
 func init() {
 	Fns = getFns()
+	if os.Getenv("ABS_COMMAND_EXECUTOR") == "" {
+		// Set the executor for system commands
+		// thanks to @haifenghuang
+		os.Setenv("ABS_COMMAND_EXECUTOR", "bash -c")
+
+		if runtime.GOOS == "windows" {
+			os.Setenv("ABS_COMMAND_EXECUTOR", "cmd.exe /C")
+		}
+	}
 }
 
 func newError(tok token.Token, format string, a ...interface{}) *object.Error {
@@ -1479,17 +1488,8 @@ func evalCommandExpression(tok token.Token, cmd string, env *object.Environment)
 	// The string holding the command
 	s := &object.String{}
 
-	// thanks to @haifenghuang
-	var commands []string
-	var executor string
-	if runtime.GOOS == "windows" {
-		commands = []string{"/C", cmd}
-		executor = "cmd.exe"
-	} else { //assume it's linux, darwin, freebsd, openbsd, solaris, etc
-		commands = []string{"-c", cmd}
-		executor = "bash"
-	}
-	c := exec.Command(executor, commands...)
+	parts := strings.Split(os.Getenv("ABS_COMMAND_EXECUTOR"), " ")
+	c := exec.Command(parts[0], append(parts[1:], cmd)...)
 	c.Env = os.Environ()
 	c.Stdin = os.Stdin
 	var stdout bytes.Buffer

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -29,6 +29,7 @@ func logErrorWithPosition(t *testing.T, msg string, expected interface{}) {
 		t.Error(expectedStr, "\ngot=", errorStr)
 	}
 }
+
 func TestEvalFloatExpression(t *testing.T) {
 	tests := []struct {
 		input    string
@@ -1223,6 +1224,9 @@ func TestCommand(t *testing.T) {
 			{"`echo 123; sleep 10 &`.ok", false},
 			{"`echo 123; sleep 10 &`.kill().done", true},
 			{"`echo 123; sleep 10 &`.kill().ok", false},
+			{"`echo \\$0`", "bash"},
+			{"env('ABS_COMMAND_EXECUTOR', 'sh -c'); `echo \\$0`", "sh"},
+			{"env('ABS_COMMAND_EXECUTOR', 'bash -c'); `echo \\$0`", "bash"},
 		}
 	}
 	for _, tt := range tests {

--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -14,7 +14,6 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -2427,19 +2426,9 @@ func execFn(tok token.Token, env *object.Environment, args ...object.Object) obj
 	// interpolate any $vars in the cmd string
 	cmd = util.InterpolateStringVars(cmd, env)
 
-	var commands []string
-	var executor string
-	if runtime.GOOS == "windows" {
-		commands = []string{"/C", cmd}
-		executor = "cmd.exe"
-	} else { //assume it's linux, darwin, freebsd, openbsd, solaris, etc
-		// invoke bash commands with login option (-l) --
-		// this allows the use of commands in $PATH
-		commands = []string{"-lc", cmd}
-		executor = "bash"
-	}
 	// set up command to execute using our stdIO
-	c := exec.Command(executor, commands...)
+	parts := strings.Split(os.Getenv("ABS_COMMAND_EXECUTOR"), " ")
+	c := exec.Command(parts[0], append(parts[1:], cmd)...)
 	c.Env = os.Environ()
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout


### PR DESCRIPTION
You can now specify a different shell to execute system commands
with through `ABS_COMMAND_EXECUTOR`:

```sh
`echo \$0` # bash
env("ABS_COMMAND_EXECUTOR", "sh -c")
`echo \$0` # sh
```

Ideally we would have liked to implement this through:

```
require('@runtime').shell = "sh -c"
```

but it's much easier to do so through an environment variable.