### PR TITLE
Ability to defer functions, closes #403

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -25,17 +25,26 @@ type Expression interface {
 	expressionNode()
 }
 
+// Deferrable is used to be able to
+// check whether an expression needs
+// to be executed now or at the end
+// of the scope
 type Deferrable interface {
 	IsDeferred() bool
 	SetDeferred(bool)
 }
 
+// Deferred is a struct that can be embedded
+// in order to define whether the current node
+// needs to be executed right away or whether
+// it should be deferred until the end of the
+// current scope.
 type Deferred struct {
-	Defer bool
+	deferred bool
 }
 
-func (d *Deferred) IsDeferred() bool          { return d.Defer }
-func (d *Deferred) SetDeferred(deferred bool) { d.Defer = deferred }
+func (d *Deferred) IsDeferred() bool          { return d.deferred }
+func (d *Deferred) SetDeferred(deferred bool) { d.deferred = deferred }
 
 // Represents the whole program
 // as a bunch of statements

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -25,6 +25,18 @@ type Expression interface {
 	expressionNode()
 }
 
+type Deferrable interface {
+	IsDeferred() bool
+	SetDeferred(bool)
+}
+
+type Deferred struct {
+	Defer bool
+}
+
+func (d *Deferred) IsDeferred() bool          { return d.Defer }
+func (d *Deferred) SetDeferred(deferred bool) { d.Defer = deferred }
+
 // Represents the whole program
 // as a bunch of statements
 type Program struct {
@@ -275,6 +287,7 @@ type MethodExpression struct {
 	Method    Expression
 	Arguments []Expression
 	Optional  bool
+	Deferred
 }
 
 func (me *MethodExpression) expressionNode()      {}
@@ -416,6 +429,7 @@ func (fe *ForExpression) String() string {
 type CommandExpression struct {
 	Token token.Token // The command itself
 	Value string
+	Deferred
 }
 
 func (ce *CommandExpression) expressionNode()      {}
@@ -479,6 +493,7 @@ type CallExpression struct {
 	Token     token.Token // The '(' token
 	Function  Expression  // Identifier or FunctionLiteral
 	Arguments []Expression
+	Deferred
 }
 
 func (ce *CallExpression) expressionNode()      {}

--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -82,6 +82,7 @@ module.exports = {
             'syntax/system-commands',
             'syntax/operators',
             'syntax/comments',
+            'syntax/defer',
           ]
         },
         {

--- a/docs/src/docs/syntax/defer.md
+++ b/docs/src/docs/syntax/defer.md
@@ -1,0 +1,57 @@
+---
+permalink: /syntax/defer
+---
+
+# Defer <Badge text="experimental" type="warning"/>
+
+Sometimes it is very helpful to guarantee a certain function is executed
+regardless of what code path we take: you can use the `defer` keyword for
+this.
+
+```py
+echo(1)
+defer echo(3)
+echo(2)
+# 1
+# 2
+# 3
+```
+
+When you schedule a function to be deferred, it will executed right at
+the end of the current scope. A `defer` inside a function will then
+execute at the end of that function itself:
+
+```py
+echo(1)
+f fn() {
+    defer echo(3)
+    echo(2)
+}
+fn()
+echo(4)
+# 1
+# 2
+# 3
+# 4
+```
+
+You can `defer` any callable: a function call, a method or even a system
+command. This can be very helpful if you need to run a cleanup function
+right before wrapping up with your code:
+
+```sh
+defer `rm my-file.txt`
+"some text" > "my-file.txt"
+
+...
+...
+"some other text" >> "my-file.txt"
+```
+
+In this case, you will be guaranteed to execute the command that removes
+`my-file.txt` before the program closes.
+
+Be aware that code that is deferred does not have access to the return value
+of its scope, and will supress errors -- if a `defer` block messes up you're
+not going to see any error. This behavior is experimental, but we would most
+likely like to give this kind of control through [try...catch...finally](https://github.com/abs-lang/abs/issues/118).

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -119,6 +119,7 @@ f hello(x, y) {
 1 !in []
 !in_variable_named_in
 !i
+defer fn
 `
 
 	tests := []struct {
@@ -414,6 +415,8 @@ f hello(x, y) {
 		{token.IDENT, "in_variable_named_in"},
 		{token.BANG, "!"},
 		{token.IDENT, "i"},
+		{token.DEFER, "defer"},
+		{token.IDENT, "fn"},
 		{token.EOF, ""},
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -116,6 +116,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.CONTINUE, p.parseContinue)
 	p.registerPrefix(token.CURRENT_ARGS, p.parseCurrentArgsLiteral)
 	p.registerPrefix(token.AT, p.parseDecorator)
+	p.registerPrefix(token.DEFER, p.parseDefer)
 
 	p.infixParseFns = make(map[token.TokenType]infixParseFn)
 	p.registerInfix(token.PLUS, p.parseInfixExpression)
@@ -846,6 +847,20 @@ func (p *Parser) parseDecorator() ast.Expression {
 	dc.Expression = exp.Expression
 
 	return dc
+}
+
+// defer fn()
+func (p *Parser) parseDefer() ast.Expression {
+	p.nextToken()
+	exp := p.parseExpression(0)
+
+	if d, ok := exp.(ast.Deferrable); ok {
+		d.SetDeferred(true)
+	} else {
+		p.reportError("you can only defer a call: defer some.method() | defer `some command` | defer some_fn()", p.curToken)
+	}
+
+	return exp
 }
 
 // ...

--- a/token/token.go
+++ b/token/token.go
@@ -83,6 +83,7 @@ const (
 	NOT_IN   = "NOT_IN"
 	BREAK    = "BREAK"
 	CONTINUE = "CONTINUE"
+	DEFER    = "DEFER"
 )
 
 type Token struct {
@@ -104,6 +105,7 @@ var keywords = map[string]TokenType{
 	"null":     NULL,
 	"break":    BREAK,
 	"continue": CONTINUE,
+	"defer":    DEFER,
 }
 
 // NumberAbbreviations is a list of abbreviations that can be used in numbers eg. 1k, 20B


### PR DESCRIPTION
Sometimes it is very helpful to guarantee a certain function is executed
regardless of what code path we take: you can use the `defer` keyword for
this.

```py
echo(1)
defer echo(3)
echo(2)
```

When you schedule a function to be deferred, it will executed right at
the end of the current scope. A `defer` inside a function will then
execute at the end of that function itself:

```py
echo(1)
f fn() {
    defer echo(3)
    echo(2)
}
fn()
echo(4)
```

You can `defer` any callable: a function call, a method or even a system
command. This can be very helpful if you need to run a cleanup function
right before wrapping up with your code:

```sh
defer `rm my-file.txt`
"some text" > "my-file.txt"

...
...
"some other text" >> "my-file.txt"
```

In this case, you will be guaranteed to execute the command that removes
`my-file.txt` before the program closes.

Be aware that code that is deferred does not have access to the return value
of its scope, and will supress errors -- if a `defer` block messes up you're
not going to see any error. This behavior is experimental, but we would most
likely like to give this kind of control through [try...catch...finally](https://github.com/abs-lang/abs/issues/118).