### PR TITLE
docs) wrong function name, fixed

### DIFF
--- a/docs/src/docs/types/array.md
+++ b/docs/src/docs/types/array.md
@@ -371,8 +371,8 @@ Returns true when at least one of the elements in the array
 returns `true` when applied to the function `f`:
 
 ```py
-[0, 1, 2].map(f(x){x == 1}) # true
-[0, 1, 2].map(f(x){x == 4}) # false
+[0, 1, 2].some(f(x){x == 1}) # true
+[0, 1, 2].some(f(x){x == 4}) # false
 ```
 
 ### sort()


### PR DESCRIPTION
The file encoding format is not uniform, not sure if there is a problem

```
% file docs/src/docs/types/*
docs/src/docs/types/array.md:            ASCII text
docs/src/docs/types/builtin-function.md: UTF-8 Unicode text
docs/src/docs/types/decorator.md:        UTF-8 Unicode text
docs/src/docs/types/function.md:         UTF-8 Unicode text
docs/src/docs/types/hash.md:             ASCII text
docs/src/docs/types/number.md:           ASCII text
docs/src/docs/types/string.md:           UTF-8 Unicode text
```