### PR TITLE
Ability to call a concurrent function like a goroutine: fn.go(args)

### DIFF
--- a/evaluator/functions.go
+++ b/evaluator/functions.go
@@ -163,6 +163,11 @@ func getFns() map[string]*object.Builtin {
 			Types: []string{object.FUNCTION_OBJ, object.BUILTIN_OBJ},
 			Fn:    callFn,
 		},
+		// fn.go(args_array)
+		"go": &object.Builtin{
+			Types: []string{object.FUNCTION_OBJ, object.BUILTIN_OBJ},
+			Fn:    callGo,
+		},
 		// chnk([...], int:2)
 		"chunk": &object.Builtin{
 			Types: []string{object.ARRAY_OBJ},
@@ -985,6 +990,18 @@ func callFn(tok token.Token, env *object.Environment, args ...object.Object) obj
 	}
 
 	return applyFunction(tok, args[0], env, args[1].(*object.Array).Elements)
+}
+
+// fn.go(args_array)
+func callGo(tok token.Token, env *object.Environment, args ...object.Object) object.Object {
+	err := validateArgs(tok, "call", args, 2, [][]string{{object.FUNCTION_OBJ, object.BUILTIN_OBJ}, {object.ARRAY_OBJ}})
+	if err != nil {
+		return err
+	}
+
+	go applyFunction(tok, args[0], env, args[1].(*object.Array).Elements)
+
+	return NULL
 }
 
 // chunk([...], integer:2)


### PR DESCRIPTION
`go` calls a function with the arguments passed:

``` bash
multiplier = f(x, y) { x * y }
multiplier.go([10, 2]) # 20
```